### PR TITLE
Fix pagination issue

### DIFF
--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -121,6 +121,7 @@ function Invoke-BitbucketAPI {
     if($Paginated){
         $_endpoint = $URI
         $counter = 0
+
         # Process Pagination
         do
         {
@@ -130,7 +131,7 @@ function Invoke-BitbucketAPI {
             # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
             If ($return.next -like '*bitbucket-pipelines.prod.public.atl-paas.net*') {
               $counter++
-              $_endpoint = $_endpoint -replace('bitbucket-pipelines.prod.public.atl-paas.net','api.bitbucket.org') -replace ("page=$counter", "page=$($counter+1)")
+              $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
             }
             Else {
               $_endpoint = $return.next

--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -142,8 +142,7 @@ function Invoke-BitbucketAPI {
                     $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
                 }
             }
-
-
+            $response += $return.values
         }
         while ($return.next)
 

--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -119,24 +119,26 @@ function Invoke-BitbucketAPI {
     }
 
     if($Paginated){
-        $_endpoint = $URI
         $counter = 0
+        $baseURL = ($URI.split('?'))[0]
+        $_endpoint = $URI
 
         # Process Pagination
         do
         {
+            # Avoid any sort of redirect to a separate hostname or endpoint and only follow the new query parameters for pagination
+            $counter++
+            $_endpoint = "$($baseUrl)?$(($_endpoint.split('?'))[1])"
             Write-Debug "URI: $_endpoint"
             $return = Invoke-RestMethod -Uri $_endpoint -Method $Method -Body $Body -Headers $Auth.GetAuthHeader() -ContentType $ContentType
 
             # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
-            If ($return.next -like '*bitbucket-pipelines.prod.public.atl-paas.net*') {
-              $counter++
-              $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
+            If ($baseURL -match '.*\/repositories\/.*\/.*\/deployments\/') {
+                $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
             }
             Else {
-              $_endpoint = $return.next
+                $_endpoint = $return.next
             }
-            $response += $return.values
         }
         while ($return.next)
 

--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -131,13 +131,15 @@ function Invoke-BitbucketAPI {
             $_endpoint = $return.next
 
             # Avoid any sort of redirect to a separate hostname or endpoint and only follow the new query parameters for pagination
-            $queryParts = $_endpoint.split('?')
-            $queryString = $queryParts[1..$($queryParts.count)] -join('')
-            $_endpoint = "$($baseURL)?$queryString"
+            If ($_endpoint) {
+                $queryParts = $_endpoint.split('?')
+                $queryString = $queryParts[1..$($queryParts.count)] -join('')
+                $_endpoint = "$($baseURL)?$queryString"
+            }
 
             # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
             $counter++
-            If ($baseURL -match '.*\/repositories\/.*\/.*\/deployments\/') {
+            If ($baseURL -match '2\.0\/repositories\/[^\/]*\/[^\/]*\/deployments\/$') {
                 $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
             }
         }

--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -135,13 +135,15 @@ function Invoke-BitbucketAPI {
                 $queryParts = $_endpoint.split('?')
                 $queryString = $queryParts[1..$($queryParts.count)] -join('')
                 $_endpoint = "$($baseURL)?$queryString"
+
+                # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
+                If ($baseURL -match '2\.0\/repositories\/[^\/]*\/[^\/]*\/deployments\/$') {
+                    $counter++
+                    $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
+                }
             }
 
-            # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
-            $counter++
-            If ($baseURL -match '2\.0\/repositories\/[^\/]*\/[^\/]*\/deployments\/$') {
-                $_endpoint = $_endpoint -replace ("page=$counter", "page=$($counter+1)")
-            }
+
         }
         while ($return.next)
 

--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -120,13 +120,21 @@ function Invoke-BitbucketAPI {
 
     if($Paginated){
         $_endpoint = $URI
-
+        $counter = 0
         # Process Pagination
         do
         {
             Write-Debug "URI: $_endpoint"
             $return = Invoke-RestMethod -Uri $_endpoint -Method $Method -Body $Body -Headers $Auth.GetAuthHeader() -ContentType $ContentType
-            $_endpoint = $return.next
+
+            # Workaround bug BCLOUD-20796 (https://jira.atlassian.com/browse/BCLOUD-20796) - Incorrect URL in next property on /repositories/{workspace}/{repo_slug}/deployments/ endpoint
+            If ($return.next -like '*bitbucket-pipelines.prod.public.atl-paas.net*') {
+              $counter++
+              $_endpoint = $_endpoint -replace('bitbucket-pipelines.prod.public.atl-paas.net','api.bitbucket.org') -replace ("page=$counter", "page=$($counter+1)")
+            }
+            Else {
+              $_endpoint = $return.next
+            }
             $response += $return.values
         }
         while ($return.next)

--- a/Atlassian.Bitbucket.Repository.Deployment.psm1
+++ b/Atlassian.Bitbucket.Repository.Deployment.psm1
@@ -44,6 +44,6 @@ function Get-BitbucketRepositoryDeployment {
             }
         }
 
-        return Invoke-BitbucketAPI -Path $endpoint -Paginated
+        return (Invoke-BitbucketAPI -Path $endpoint).values
     }
 }

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.26.0'
+    ModuleVersion     = '0.27.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ _These will be removed in the next major release_
 
 - N/A
 
+## 0.27.0
+- Added work around to Invoke-BitbucketAPI for bug [BCLOUD-20796](https://jira.atlassian.com/browse/BCLOUD-20796)
+
 ## 0.26.0
 - Added `Add-BitbucketUserToGroup`
 - Added `Get-BitbucketGroup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ _These will be removed in the next major release_
 - N/A
 
 ## 0.27.0
-- Added work around to Invoke-BitbucketAPI for bug [BCLOUD-20796](https://jira.atlassian.com/browse/BCLOUD-20796)
+- Updated pagination to build up the next page URL and avoid redirects to hostnames other than the original API, such as in this bug [BCLOUD-20796](https://jira.atlassian.com/browse/BCLOUD-20796)
+- Fixed deployment endpoint to properly return only the number of items specified in limit
 
 ## 0.26.0
 - Added `Add-BitbucketUserToGroup`


### PR DESCRIPTION
# Why
Bitbucket has known bug [BCLOUD-20796](https://jira.atlassian.com/browse/BCLOUD-20796) where pagination is broken for the /repositories/{workspace}/{repo_slug}/deployments/ endpoint.  

# What
Added some logic so that if a known bad hostname is returned in the 'next' property, it is replaced and the original endpoint is used with an incremented page number.  This is done because the entire URL returned for pagination is incorrect and cannot be used.  

# Testing
Tested locally with a 78 page response and verified success.