### PR TITLE
Add-bitbucketRepositoryRestriction now properly removes branch_match_kind property

### DIFF
--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -53,7 +53,7 @@ function New-BitbucketLogin {
 
         Write-Output "Welcome $($Auth.User.display_name)"
 
-        Select-BitbucketTeam
+        Select-BitbucketWorkspace
 
         if($Save){
             Save-BitbucketLogin
@@ -94,7 +94,7 @@ function Invoke-BitbucketAPI {
     [CmdletBinding()]
     param(
         [String]$Path = '',
-        [Microsoft.PowerShell.Commands.WebRequestMethod]$Method = 'Get',
+        [String]$Method = 'Get',
         [Object]$Body,
         [Switch]$Paginated,
         [Int32]$MaxPages = 2147483647,
@@ -156,46 +156,50 @@ function Invoke-BitbucketAPI {
     }
 }
 
-function Get-BitbucketTeam {
+function Get-BitbucketWorkspace {
     [CmdletBinding()]
+    [Alias("Get-BitbucketTeam")]
     param(
-        [ValidateSet('admin', 'contributor', 'member')]
+        [ValidateSet('owner', 'collaborator', 'member')]
         [String]$Role = 'member'
     )
-    $endpoint = "teams?role=$Role"
+    $endpoint = "workspaces?role=$Role"
 
     return (Invoke-BitbucketAPI -Path $endpoint).values
 }
 
-function Get-BitbucketSelectedTeam {
+function Get-BitbucketSelectedWorkspace {
     [CmdletBinding()]
+    [Alias("Get-BitbucketSelectedTeam")]
     param(
     )
 
     $Auth = [BitbucketAuth]::GetInstance()
-    return $Auth.Team
+    return $Auth.Workspace
 }
 
-function Select-BitbucketTeam {
+function Select-BitbucketWorkspace {
     [CmdletBinding()]
+    [Alias("Select-BitbucketTeam")]
     param(
-        [String]$Team
+        [Alias("Team")]
+        [String]$Workspace
     )
 
-    if(!$Team){
-        $Teams = Get-BitbucketTeam
+    if(!$Workspace){
+        $Workspaces = Get-BitbucketWorkspace
         $index = 0
 
-        if($Teams.count -gt 1){
+        if($Workspaces.count -gt 1){
 
-            for ($i = 0; $i -lt $Teams.Count; $i++) {
-                Write-Output "$i - $($Teams[$i].username)"
+            for ($i = 0; $i -lt $Workspaces.Count; $i++) {
+                Write-Output "$i - $($Workspaces[$i].name)"
             }
-            [int]$index = Read-Host 'Which team would you like to use?'
+            [int]$index = Read-Host 'Which workspace would you like to use?'
         }
-        $Team = $Teams[$index].username
+        $Workspace = $Workspaces[$index].slug
     }
 
     $Auth = [BitbucketAuth]::GetInstance()
-    $Auth.Team = $Team
+    $Auth.Workspace = $Workspace
 }

--- a/Atlassian.Bitbucket.Pipeline.Variable.psm1
+++ b/Atlassian.Bitbucket.Pipeline.Variable.psm1
@@ -3,87 +3,90 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketRepositoryVariable {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug
     )
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pipelines_config/variables/"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines_config/variables/"
         return (Invoke-BitbucketAPI -Path $endpoint).values
     }
 }
 
 function New-BitbucketRepositoryVariable {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the environment.')]
+        [Parameter( Mandatory = $true,
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the environment.')]
         [string]$Key,
-        [Parameter( Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Variable value')]
+        [Parameter( Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Variable value')]
         [string]$Value,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Obscure the variable value')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Obscure the variable value')]
         [switch]$Secured
 
     )
     Process {
         $body = [ordered]@{
-            key = $Key
+            key     = $Key
             secured = $Secured.IsPresent
-            value = $Value
+            value   = $Value
         } | ConvertTo-Json -Depth 1 -Compress
 
-        $endpoint = "repositories/$Team/$RepoSlug/pipelines_config/variables/"
-        if ($pscmdlet.ShouldProcess("$Key in the repo $RepoSlug", 'create')){
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines_config/variables/"
+        if ($pscmdlet.ShouldProcess("$Key in the repo $RepoSlug", 'create')) {
             return Invoke-BitbucketAPI -Path $endpoint -Method Post -Body $body
         }
     }
 }
 
 function Remove-BitbucketRepositoryVariable {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Variable key')]
+        [Parameter( Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Variable key')]
         [string]$Key
     )
     Process {
-        $_uuidVar = (Get-BitbucketRepositoryVariable -Team $Team -RepoSlug $RepoSlug | Where-Object {$_.key -eq $Key}).uuid
-        if($_uuidVar){
-            $endpoint = "repositories/$Team/$RepoSlug/pipelines_config/variables/$_uuidVar"
-            if ($pscmdlet.ShouldProcess("$Key in the repo $RepoSlug", 'delete')){
+        $_uuidVar = (Get-BitbucketRepositoryVariable -Workspace $Workspace -RepoSlug $RepoSlug | Where-Object { $_.key -eq $Key }).uuid
+        if ($_uuidVar) {
+            $endpoint = "repositories/$Workspace/$RepoSlug/pipelines_config/variables/$_uuidVar"
+            if ($pscmdlet.ShouldProcess("$Key in the repo $RepoSlug", 'delete')) {
                 return Invoke-BitbucketAPI -Path $endpoint -Method Delete
             }
         }

--- a/Atlassian.Bitbucket.Pipeline.psm1
+++ b/Atlassian.Bitbucket.Pipeline.psm1
@@ -2,81 +2,83 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 
 function Enable-BitbucketPipelineConfig {
 
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param (
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pipelines_config"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines_config"
 
         $body = @{
             enabled = $true
         } | ConvertTo-Json -Depth 1 -Compress
 
-        if ($pscmdlet.ShouldProcess("pipelines on repo $RepoSlug", 'enable'))
-        {
+        if ($pscmdlet.ShouldProcess("pipelines on repo $RepoSlug", 'enable')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body -Method Put
         }
     }
 }
 
 function Get-BitbucketPipelineConfig {
-  param (
-      [Parameter( ValueFromPipelineByPropertyName=$true,
-                  HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-      [string]$Team = (Get-BitbucketSelectedTeam),
-      [Parameter( Mandatory=$true,
-                  Position=0,
-                  ValueFromPipeline=$true,
-                  ValueFromPipelineByPropertyName=$true,
-                  HelpMessage='The repository slug.')]
-      [Alias('Slug')]
-      [string]$RepoSlug
-  )
+    param (
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
+        [Alias('Slug')]
+        [string]$RepoSlug
+    )
 
-  Process {
-      $endpoint = "repositories/$Team/$RepoSlug/pipelines_config"
+    Process {
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines_config"
 
-      return Invoke-BitbucketAPI -Path $endpoint -Method Get
-  }
+        return Invoke-BitbucketAPI -Path $endpoint -Method Get
+    }
 }
 
 function Start-BitbucketPipeline {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param (
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Position=1,
-                    ValueFromPipelineByPropertyName=$true)]
+        [Parameter( Position = 1,
+            ValueFromPipelineByPropertyName = $true)]
         [string]$Branch = 'master',
-        [Parameter( Position=2,
-                    ValueFromPipelineByPropertyName=$true)]
+        [Parameter( Position = 2,
+            ValueFromPipelineByPropertyName = $true)]
         [string]$CustomPipe,
-        [Parameter( Position=3,
-                    ValueFromPipelineByPropertyName=$true)]
+        [Parameter( Position = 3,
+            ValueFromPipelineByPropertyName = $true)]
         [HashTable[]]$Variables
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pipelines/"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines/"
 
         # Add selector for custom pipes
         if ($CustomPipe) {
@@ -91,7 +93,8 @@ function Start-BitbucketPipeline {
                     }
                 }
             }
-        }else {
+        }
+        else {
             $body = [ordered]@{
                 target = [ordered]@{
                     type     = 'pipeline_ref_target'
@@ -108,8 +111,7 @@ function Start-BitbucketPipeline {
 
         $body = $body | ConvertTo-Json -Depth 5 -Compress
 
-        if ($pscmdlet.ShouldProcess('pipeline', 'start'))
-        {
+        if ($pscmdlet.ShouldProcess('pipeline', 'start')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body -Method Post
         }
     }
@@ -118,20 +120,21 @@ function Start-BitbucketPipeline {
 function Wait-BitbucketPipeline {
     [CmdletBinding()]
     param (
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Position=0,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Position = 0,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository object from Bitbucket.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository object from Bitbucket.')]
         $repository,
-        [Parameter( Position=1,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true)]
+        [Parameter( Position = 1,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true)]
         [Alias('uuid')]
         [string]$PipelineUUID,
         [int]$SleepSeconds = 10,
@@ -139,15 +142,15 @@ function Wait-BitbucketPipeline {
     )
 
     Process {
-        if($repository){
+        if ($repository) {
             $RepoSlug = $repository.uuid
         }
 
-        if(!$RepoSlug){
+        if (!$RepoSlug) {
             Throw 'A repo must be provided'
         }
 
-        $endpoint = "repositories/$Team/$RepoSlug/pipelines/$PipelineUUID"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pipelines/$PipelineUUID"
         Write-Progress -Id 0 'Watching pipeline for successful completion...'
 
         $poll = $true
@@ -155,12 +158,14 @@ function Wait-BitbucketPipeline {
         do {
             $response = Invoke-BitbucketAPI -Path $endpoint
 
-            if($response.state.name -eq 'COMPLETED'){
+            if ($response.state.name -eq 'COMPLETED') {
                 $poll = $false
-            }else{
-                if($TimeoutSeconds -lt $SleepSeconds){
+            }
+            else {
+                if ($TimeoutSeconds -lt $SleepSeconds) {
                     Throw "The $TimeoutSeconds second timeout expired before the pipeline completed."
-                }else{
+                }
+                else {
                     Write-Verbose "Pipeline has not completed yet.  Waiting for $SleepSeconds more seconds before re-checking.  $TimeoutSeconds left before timing out."
                     $TimeoutSeconds -= $SleepSeconds
                     Start-Sleep -Seconds $SleepSeconds

--- a/Atlassian.Bitbucket.Project.psm1
+++ b/Atlassian.Bitbucket.Project.psm1
@@ -2,21 +2,21 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 
 <#
     .SYNOPSIS
-        Returns all Projects in the team.
+        Returns all Projects in the workspace.
 
     .DESCRIPTION
-        Returns all the Bitbucket Projects in the team, or the specific project if specified.
+        Returns all the Bitbucket Projects in the workspace, or the specific project if specified.
 
     .EXAMPLE
         C:\PS> Get-BitbucketProject
-        Returns all projects for the currently selected team.
+        Returns all projects for the currently selected workspace.
 
     .EXAMPLE
         C:\PS> Get-BitbucketProject -ProjectKey 'KEY'
         Returns the project specified by the key if found.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER ProjectKey
         Project key in Bitbucket
@@ -24,27 +24,26 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketProject {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$false,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Project key in Bitbucket')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $false,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Project key in Bitbucket')]
         [string]$ProjectKey
     )
 
     Process {
-        $endpoint = "teams/$Team/projects/"
-        if($ProjectKey)
-        {
+        $endpoint = "workspaces/$Workspace/projects/"
+        if ($ProjectKey) {
             # Fetch a specific project
             $endpoint += $ProjectKey
             return Invoke-BitbucketAPI -Path $endpoint
         }
-        else
-        {
+        else {
             return Invoke-BitbucketAPI -Path $endpoint -Paginated
         }
     }

--- a/Atlassian.Bitbucket.PullRequest.Comment.psm1
+++ b/Atlassian.Bitbucket.PullRequest.Comment.psm1
@@ -11,8 +11,8 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
         C:\PS> Get-BitbucketPullRequestComment -RepoSlug 'Repo' -PullRequestID 1
         Returns all the comments on PR 1 in the `Repo` repository
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -23,25 +23,26 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketPullRequestComment {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
-                    Position = 0,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The repository slug.')]
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
         [Parameter( Mandatory = $true,
-                    Position = 1,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The ID of the Pull Request')]
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The ID of the Pull Request')]
         [Alias('ID')]
         [string]$PullRequestID
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pullrequests/$PullRequestID/comments"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pullrequests/$PullRequestID/comments"
 
         return Invoke-BitbucketAPI -Path $endpoint -Paginated
     }
@@ -62,8 +63,8 @@ function Get-BitbucketPullRequestComment {
         C:\PS> New-BitbucketPullRequestComment -RepoSlug 'Repo' -PullRequestID 1 -Comment "# Heading1 `n * Item1 `n * Item2"
         Creates a new comment with markdown against the PR as the authenticated user.  Includes an h1 heading and bullet items.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -75,40 +76,41 @@ function Get-BitbucketPullRequestComment {
         The text to use in the comment.  Supports Markdown.
 #>
 function New-BitbucketPullRequestComment {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
-                    Position = 0,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The repository slug.')]
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
         [Parameter( Mandatory = $true,
-                    Position = 1,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The ID of the Pull Request')]
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The ID of the Pull Request')]
         [Alias('ID')]
         [string]$PullRequestID,
         [Parameter( Mandatory = $true,
-                    Position = 2,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'Comment to add to the Pull Request.  Supports Markdown for formatting.')]
+            Position = 2,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Comment to add to the Pull Request.  Supports Markdown for formatting.')]
         [string]$Comment
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pullrequests/$PullRequestID/comments"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pullrequests/$PullRequestID/comments"
 
         $body = [ordered]@{
             content = [ordered]@{
-                raw =  $Comment
+                raw = $Comment
             }
         } | ConvertTo-Json -Depth 2 -Compress
 
-        if ($pscmdlet.ShouldProcess("PR $PullRequestID in $RepoSlug", 'create pull request comment')){
+        if ($pscmdlet.ShouldProcess("PR $PullRequestID in $RepoSlug", 'create pull request comment')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body -Method Post
         }
     }

--- a/Atlassian.Bitbucket.PullRequest.psm1
+++ b/Atlassian.Bitbucket.PullRequest.psm1
@@ -15,8 +15,8 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
         C:\PS> Get-BitbucketPullRequest -RepoSlug 'Repo' -State 'MERGED'
         Returns all merged PR's against the `Repo` repository.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -27,9 +27,10 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketPullRequest {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true,
@@ -38,18 +39,17 @@ function Get-BitbucketPullRequest {
         [Alias('Slug')]
         [string]$RepoSlug,
         [Parameter( ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The state of the PR.  Defaults to OPEN')]
+            HelpMessage = 'The state of the PR.  Defaults to OPEN')]
         [ValidateSet('OPEN', 'MERGED', 'SUPERSEDED', 'DECLINED')]
         [string]$State = 'OPEN'
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pullrequests"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pullrequests"
 
         # To Do - Add Filtering as needed https://developer.atlassian.com/bitbucket/api/2/reference/meta/filtering#query-pullreq
         # Most Repos have small sets of PR's so client side will work for now until a use case comes up besides state.
-        if($State)
-        {
+        if ($State) {
             $endpoint += "?q=state=%22$State%22"
         }
 
@@ -77,8 +77,8 @@ function Get-BitbucketPullRequest {
         Creates a PR and includes the default reviewers for the repo on the PR.
         The user creating the PR can not be included in the reviewers list.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -102,56 +102,57 @@ function Get-BitbucketPullRequest {
         Array of user objects of the reviewers to add to the PR.  Uses the uuid property on the object.  Defaults to no reviewers.  To include the default list use the (Get-BitbucketRepositoryReviewer <repo>) command.
 #>
 function New-BitbucketPullRequest {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
-                    Position = 0,
-                    ValueFromPipeline = $true,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The repository slug.')]
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
         [Parameter( Mandatory = $true,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'Title of the PR.')]
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Title of the PR.')]
         [string]$Title,
         [Parameter( Mandatory = $true,
-                    ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The source branch for the PR.')]
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The source branch for the PR.')]
         [string]$SourceBranch,
         [Parameter( ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'Description for the PR.')]
+            HelpMessage = 'Description for the PR.')]
         [string]$Description,
         [Parameter( ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'Should the source branch be closed after PR is merged.  Defaults to True.')]
+            HelpMessage = 'Should the source branch be closed after PR is merged.  Defaults to True.')]
         [bool]$CloseBranch = $true,
         [Parameter( ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'The destination branch for the PR.  Defaults to the repositories main branch specified in Bitbucket.')]
+            HelpMessage = 'The destination branch for the PR.  Defaults to the repositories main branch specified in Bitbucket.')]
         [string]$DestinationBranch,
         [Parameter( ValueFromPipelineByPropertyName = $true,
-                    HelpMessage = 'An array of user objects to include on the PR.  Only needs the uuid property on the object.')]
+            HelpMessage = 'An array of user objects to include on the PR.  Only needs the uuid property on the object.')]
         [psobject[]]$Reviewers = @()
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/pullrequests"
+        $endpoint = "repositories/$Workspace/$RepoSlug/pullrequests"
 
         $body = [ordered]@{
-            title =  $Title
-            description = $Description
+            title               = $Title
+            description         = $Description
             close_source_branch = $CloseBranch
-            source = [ordered]@{
+            source              = [ordered]@{
                 branch = [ordered]@{
                     name = $SourceBranch
                 }
             }
-            reviewers = $Reviewers
+            reviewers           = $Reviewers
         }
 
-        if($DestinationBranch){
+        if ($DestinationBranch) {
             $body += [ordered]@{
                 destination = @{
                     branch = @{
@@ -163,7 +164,7 @@ function New-BitbucketPullRequest {
 
         $body = $body | ConvertTo-Json -Depth 3 -Compress
 
-        if ($pscmdlet.ShouldProcess($RepoSlug, 'Create pull request')){
+        if ($pscmdlet.ShouldProcess($RepoSlug, 'Create pull request')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body -Method Post
         }
     }

--- a/Atlassian.Bitbucket.Reports.psm1
+++ b/Atlassian.Bitbucket.Reports.psm1
@@ -17,8 +17,8 @@ using module .\Atlassian.Bitbucket.Repository.Environment.psm1
         C:\PS> Get-BitbucketRepository -ProjectKey 'ZEUS' | Get-BitbucketProjectDeploymentReport -Format HTML | Out-File C:\Temp\report.html
         # Generate and save the HTML report.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER Repo
         Repos used to build the report.  Pipeline in input from Get-BitbucketRepository.
@@ -32,61 +32,62 @@ using module .\Atlassian.Bitbucket.Repository.Environment.psm1
 function Get-BitbucketProjectDeploymentReport {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    ValueFromPipeline=$true,
-                    HelpMessage='Repos used to build the report.  Use the Get-BitbucketRepo command.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            ValueFromPipeline = $true,
+            HelpMessage = 'Repos used to build the report.  Use the Get-BitbucketRepo command.')]
         $Repo,
         [string[]]$Environments = ('Test', 'Staging', 'Production'),
         [ValidateSet('JSON', 'HTML')]
         [string]$Format = 'JSON'
     )
-    Begin{
+    Begin {
         $content = @()
         $_repos = @()
     }
-    Process{
+    Process {
         $_repos += $Repo
     }
-    End{
+    End {
         for ($r = 0; $r -lt $_repos.Count; $r++) {
             $_repo = $_repos[$r]
-            Write-Progress -Id 0 -Activity "Getting Deployments for Repo: $($_repo.name)" -PercentComplete ((($r + 1) / $_repos.Count)*100)
-            $_env = Get-BitbucketRepositoryEnvironment -Team $Team -RepoSlug $_repo.slug | Where-Object {$_.Name -in $Environments}
+            Write-Progress -Id 0 -Activity "Getting Deployments for Repo: $($_repo.name)" -PercentComplete ((($r + 1) / $_repos.Count) * 100)
+            $_env = Get-BitbucketRepositoryEnvironment -Workspace $Workspace -RepoSlug $_repo.slug | Where-Object { $_.Name -in $Environments }
 
             $envList = @()
 
             for ($e = 0; $e -lt $_env.Count; $e++) {
-                Write-Progress -Id 1 -Activity "Environment: $($_env[$e].name)" -PercentComplete ((($e + 1) / $_env.Count)*100)
+                Write-Progress -Id 1 -Activity "Environment: $($_env[$e].name)" -PercentComplete ((($e + 1) / $_env.Count) * 100)
                 $Fields = ('values.deployable.commit.message', 'values.deployable.commit.date', 'values.deployable.commit.author.user')
-                $deployment = Get-BitbucketRepositoryDeployment -Team $Team -RepoSlug $_repo.slug -EnvironmentUUID $_env[$e].uuid -Limit 1 -Fields $Fields
+                $deployment = Get-BitbucketRepositoryDeployment -Workspace $Workspace -RepoSlug $_repo.slug -EnvironmentUUID $_env[$e].uuid -Limit 1 -Fields $Fields
 
-                if($deployment){
+                if ($deployment) {
                     $envList += [PSCustomObject]@{
                         EnvironmentName = $_env[$e].name
-                        State = $deployment.state.name
-                        Status = $deployment.state.status.name
-                        Commit = [PSCustomObject]@{
-                            Hash = $deployment.deployable.commit.hash
+                        State           = $deployment.state.name
+                        Status          = $deployment.state.status.name
+                        Commit          = [PSCustomObject]@{
+                            Hash    = $deployment.deployable.commit.hash
                             Message = $deployment.deployable.commit.message
-                            Date = $deployment.deployable.commit.date
-                            Author = [PSCustomObject]@{
+                            Date    = $deployment.deployable.commit.date
+                            Author  = [PSCustomObject]@{
                                 User = [PSCustomObject]@{
                                     DisplayName = $deployment.deployable.commit.author.user.display_name
                                 }
                             }
                         }
-                        Pipeline = $deployment.release.name
-                        URL = $deployment.release.url
-                        Time = $deployment.last_update_time
+                        Pipeline        = $deployment.release.name
+                        URL             = $deployment.release.url
+                        Time            = $deployment.last_update_time
                     }
                 }
             }
 
             $content += [PSCustomObject]@{
-                RepoName = $_repo.name
+                RepoName     = $_repo.name
                 Environments = $envList
             }
         }
@@ -106,7 +107,7 @@ function Get-BitbucketProjectDeploymentReportHTML {
     [OutputType('System.String')]
     [CmdletBinding()]
     param(
-        [string[]]$Environments = ('Dev','Test', 'Staging', 'Production'),
+        [string[]]$Environments = ('Dev', 'Test', 'Staging', 'Production'),
         $Content
     )
 
@@ -124,64 +125,68 @@ function Get-BitbucketProjectDeploymentReportHTML {
         $previous = -1
 
         foreach ($env in $Environments) {
-            $deployment = $repo.environments | Where-Object {$_.EnvironmentName -eq $env}
+            $deployment = $repo.environments | Where-Object { $_.EnvironmentName -eq $env }
 
             # Attempt to grab the pipeline run
             [int]$current = 0
-            if($deployment){
-                [int]::TryParse($deployment.Pipeline.Replace('#',''), [ref]$current) | Out-Null
+            if ($deployment) {
+                [int]::TryParse($deployment.Pipeline.Replace('#', ''), [ref]$current) | Out-Null
             }
 
-            if($previous -ne -1){
-                if($previous -gt $current){
+            if ($previous -ne -1) {
+                if ($previous -gt $current) {
                     $cells += '<div class="compare gt">&gt;</div>'
-                }elseif($previous -eq $current){
+                }
+                elseif ($previous -eq $current) {
                     $cells += '<div class="compare">=</div>'
-                }else{
+                }
+                else {
                     $cells += '<div class="compare lt">&lt;</div>'
                 }
             }
 
             $previous = $current
 
-            if($deployment){
+            if ($deployment) {
                 # Calculate Status
-                if($deployment.State -eq 'COMPLETED'){
+                if ($deployment.State -eq 'COMPLETED') {
                     $status = $deployment.Status
-                }else{
+                }
+                else {
                     $status = $deployment.State
                 }
 
                 $cells += $HTMLCell.
-                    Replace('##ROW_ID##', $rowID).
-                    Replace('##ENVIRONMENT_NAME##', $env).
-                    Replace('##STATUS##',$status).
-                    Replace('##URL##',$deployment.URL).
-                    Replace('##PIPELINE##',$deployment.Pipeline).
-                    Replace('##COMMIT_HASH##',$deployment.Commit.Hash.Substring(0,7)).
-                    Replace('##COMMIT_MESSAGE##', $deployment.Commit.Message).
-                    Replace('##TIME##',$deployment.Time)
-            }else{
+                Replace('##ROW_ID##', $rowID).
+                Replace('##ENVIRONMENT_NAME##', $env).
+                Replace('##STATUS##', $status).
+                Replace('##URL##', $deployment.URL).
+                Replace('##PIPELINE##', $deployment.Pipeline).
+                Replace('##COMMIT_HASH##', $deployment.Commit.Hash.Substring(0, 7)).
+                Replace('##COMMIT_MESSAGE##', $deployment.Commit.Message).
+                Replace('##TIME##', $deployment.Time)
+            }
+            else {
                 $cells += $HTMLCell.
-                    Replace('##ROW_ID##', $rowID).
-                    Replace('##ENVIRONMENT_NAME##', $env).
-                    Replace('##STATUS##', 'BLANK').
-                    Replace('##URL##', '').
-                    Replace('##PIPELINE##', '').
-                    Replace('##COMMIT_HASH##', '').
-                    Replace('##COMMIT_MESSAGE##', '').
-                    Replace('##TIME##', '')
+                Replace('##ROW_ID##', $rowID).
+                Replace('##ENVIRONMENT_NAME##', $env).
+                Replace('##STATUS##', 'BLANK').
+                Replace('##URL##', '').
+                Replace('##PIPELINE##', '').
+                Replace('##COMMIT_HASH##', '').
+                Replace('##COMMIT_MESSAGE##', '').
+                Replace('##TIME##', '')
             }
         }
         $rows += $HTMLRow.
-            Replace('##ROW_ID##', $rowID).
-            Replace('##REPO##', $repo.RepoName).
-            Replace('##CELLS##', $cells)
+        Replace('##ROW_ID##', $rowID).
+        Replace('##REPO##', $repo.RepoName).
+        Replace('##CELLS##', $cells)
 
         $rowID += 1
     }
 
     return $HTMLReport.
-        Replace('##DATE##', (Get-Date).ToString()).
-        Replace('##ROWS##', $rows)
+    Replace('##DATE##', (Get-Date).ToString()).
+    Replace('##ROWS##', $rows)
 }

--- a/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
+++ b/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
@@ -48,8 +48,8 @@ function Add-BitbucketRepositoryBranchRestriction {
         }
 
         # If the branch_match_kind is Glob, remove branch_type property, otherwise the Bitbucket API will throw an exception
-        if ($Restriction.branch_match_kind -eq 'Glob') {
-            $globRestriction = $Restriction | Select-Object -ExcludeProperty branch_type
+        if ($Restriction.branch_match_kind -eq 'glob') {
+            $globRestriction = $Restriction | Select-Object -ExcludeProperty branch_type -Property *
             $body = $globRestriction | ConvertTo-Json -Depth 3 -Compress
         }
         else {

--- a/Atlassian.Bitbucket.Repository.Deployment.psm1
+++ b/Atlassian.Bitbucket.Repository.Deployment.psm1
@@ -3,14 +3,15 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketRepositoryDeployment {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
         [ValidateSet('COMPLETED', 'IN_PROGRESS', 'UNDEPLOYED')]
@@ -23,22 +24,23 @@ function Get-BitbucketRepositoryDeployment {
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/deployments/?sort=$Sort&page=$Page&pagelen=$Limit"
+        $endpoint = "repositories/$Workspace/$RepoSlug/deployments/?sort=$Sort&page=$Page&pagelen=$Limit"
 
-        if($State){
+        if ($State) {
             $endpoint += "&state.name=$State"
         }
 
-        if($EnvironmentUUID){
+        if ($EnvironmentUUID) {
             $endpoint += "&environment=$EnvironmentUUID"
         }
 
-        if($Fields){
+        if ($Fields) {
             $endpoint += '&fields='
             for ($i = 0; $i -lt $Fields.Count; $i++) {
-                if($i -lt ($Fields.Count -1)){
+                if ($i -lt ($Fields.Count - 1)) {
                     $endpoint += "%2B$($Fields[$i])%2C"
-                }else{
+                }
+                else {
                     $endpoint += "%2B$($Fields[$i])"
                 }
             }

--- a/Atlassian.Bitbucket.Repository.Environment.Variable.psm1
+++ b/Atlassian.Bitbucket.Repository.Environment.Variable.psm1
@@ -4,123 +4,129 @@ using module .\Atlassian.Bitbucket.Repository.Environment.psm1
 function Get-BitbucketRepositoryEnvironmentVariable {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the environment.')]
+        [Parameter( Mandatory = $true,
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the environment.')]
         [string]$Environment
     )
     Process {
-        $_environments = Get-BitbucketRepositoryEnvironment -Team $Team -RepoSlug $RepoSlug
-        $_uuid = ($_environments | Where-Object {$_.name -eq $Environment}).uuid
+        $_environments = Get-BitbucketRepositoryEnvironment -Workspace $Workspace -RepoSlug $RepoSlug
+        $_uuid = ($_environments | Where-Object { $_.name -eq $Environment }).uuid
 
-        if($_uuid){
-            $endpoint = "repositories/$Team/$RepoSlug/deployments_config/environments/$_uuid/variables"
+        if ($_uuid) {
+            $endpoint = "repositories/$Workspace/$RepoSlug/deployments_config/environments/$_uuid/variables"
             return Invoke-BitbucketAPI -Path $endpoint -Paginated
-        }else{
+        }
+        else {
             Throw "Couldn't find the environment: $Environment"
         }
     }
 }
 
 function New-BitbucketRepositoryEnvironmentVariable {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the environment.')]
+        [Parameter( Mandatory = $true,
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the environment.')]
         [string]$Environment,
-        [Parameter( Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Variable key')]
+        [Parameter( Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Variable key')]
         [string]$Key,
-        [Parameter( Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Variable value')]
+        [Parameter( Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Variable value')]
         [string]$Value,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Obscure the variable value')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Obscure the variable value')]
         [switch]$Secured
 
     )
     Process {
-        $_environments = Get-BitbucketRepositoryEnvironment -Team $Team -RepoSlug $RepoSlug
-        $_uuid = ($_environments | Where-Object {$_.name -eq $Environment}).uuid
+        $_environments = Get-BitbucketRepositoryEnvironment -Workspace $Workspace -RepoSlug $RepoSlug
+        $_uuid = ($_environments | Where-Object { $_.name -eq $Environment }).uuid
 
-        if($_uuid){
+        if ($_uuid) {
             $body = [ordered]@{
-                key = $Key
+                key     = $Key
                 secured = $Secured.IsPresent
-                value = $Value
+                value   = $Value
             } | ConvertTo-Json -Depth 1 -Compress
 
-            $endpoint = "repositories/$Team/$RepoSlug/deployments_config/environments/$_uuid/variables"
-            if ($pscmdlet.ShouldProcess("$Key in the environment $Environment in the repo $RepoSlug", 'create')){
+            $endpoint = "repositories/$Workspace/$RepoSlug/deployments_config/environments/$_uuid/variables"
+            if ($pscmdlet.ShouldProcess("$Key in the environment $Environment in the repo $RepoSlug", 'create')) {
                 return Invoke-BitbucketAPI -Path $endpoint -Method Post -Body $body
             }
-        }else{
+        }
+        else {
             Throw "Couldn't find the environment: $Environment"
         }
     }
 }
 
 function Remove-BitbucketRepositoryEnvironmentVariable {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='High')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the environment.')]
+        [Parameter( Mandatory = $true,
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the environment.')]
         [string]$Environment,
-        [Parameter( Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Variable key')]
+        [Parameter( Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Variable key')]
         [string]$Key
     )
     Process {
-        $_uuidEnv = (Get-BitbucketRepositoryEnvironment -Team $Team -RepoSlug $RepoSlug | Where-Object {$_.name -eq $Environment}).uuid
+        $_uuidEnv = (Get-BitbucketRepositoryEnvironment -Workspace $Workspace -RepoSlug $RepoSlug | Where-Object { $_.name -eq $Environment }).uuid
 
-        if($_uuidEnv){
-            $_uuidVar = (Get-BitbucketRepositoryEnvironmentVariable -Team $Team -RepoSlug $RepoSlug -Environment $Environment | Where-Object {$_.key -eq $Key}).uuid
+        if ($_uuidEnv) {
+            $_uuidVar = (Get-BitbucketRepositoryEnvironmentVariable -Workspace $Workspace -RepoSlug $RepoSlug -Environment $Environment | Where-Object { $_.key -eq $Key }).uuid
 
-            if($_uuidVar){
-                $endpoint = "repositories/$Team/$RepoSlug/deployments_config/environments/$_uuidEnv/variables/$_uuidVar"
-                if ($pscmdlet.ShouldProcess("$Key in the environment $Environment in the repo $RepoSlug", 'delete')){
+            if ($_uuidVar) {
+                $endpoint = "repositories/$Workspace/$RepoSlug/deployments_config/environments/$_uuidEnv/variables/$_uuidVar"
+                if ($pscmdlet.ShouldProcess("$Key in the environment $Environment in the repo $RepoSlug", 'delete')) {
                     return Invoke-BitbucketAPI -Path $endpoint -Method Delete
                 }
             }
-        }else{
+        }
+        else {
             Throw "Couldn't find the environment: $Environment"
         }
     }

--- a/Atlassian.Bitbucket.Repository.Reviewer.psm1
+++ b/Atlassian.Bitbucket.Repository.Reviewer.psm1
@@ -4,8 +4,9 @@ function Get-BitbucketRepositoryReviewer {
     [CmdletBinding()]
     Param (
         [Parameter( ValueFromPipelineByPropertyName = $true,
-            HelpMessage = 'Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true,
@@ -15,7 +16,7 @@ function Get-BitbucketRepositoryReviewer {
         [string]$RepoSlug
     )
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/default-reviewers"
+        $endpoint = "repositories/$Workspace/$RepoSlug/default-reviewers"
         return Invoke-BitbucketAPI -Path $endpoint -Method Get -Paginated
     }
 }
@@ -25,8 +26,9 @@ function Add-BitbucketRepositoryReviewer {
         ConfirmImpact = 'Medium')]
     Param (
         [Parameter( ValueFromPipelineByPropertyName = $true,
-            HelpMessage = 'Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true,
@@ -41,7 +43,7 @@ function Add-BitbucketRepositoryReviewer {
         [string]$UUID
     )
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/default-reviewers/$UUID"
+        $endpoint = "repositories/$Workspace/$RepoSlug/default-reviewers/$UUID"
 
         if ($pscmdlet.ShouldProcess($RepoSlug, "Add $UUID to default reviewers")) {
             $response = Invoke-BitbucketAPI -Path $endpoint -Method Put
@@ -49,7 +51,7 @@ function Add-BitbucketRepositoryReviewer {
             if ($response) {
                 return [pscustomobject]@{
                     UUID     = $UUID
-                    Team     = $Team
+                    Workspace = $Workspace
                     RepoSlug = $RepoSlug
                     Action   = 'Added'
                 }
@@ -67,8 +69,9 @@ function Remove-BitbucketRepositoryReviewer {
         ConfirmImpact = 'High')]
     Param (
         [Parameter( ValueFromPipelineByPropertyName = $true,
-            HelpMessage = 'Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true,
@@ -83,14 +86,14 @@ function Remove-BitbucketRepositoryReviewer {
         [string]$UUID
     )
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/default-reviewers/$UUID"
+        $endpoint = "repositories/$Workspace/$RepoSlug/default-reviewers/$UUID"
 
         if ($pscmdlet.ShouldProcess($RepoSlug, "Remove $UUID from default reviewers")) {
             Invoke-BitbucketAPI -Path $endpoint -Method Delete
 
             [pscustomobject]@{
                 UUID     = $UUID
-                Team     = $Team
+                Workspace = $Workspace
                 RepoSlug = $RepoSlug
                 Action   = 'Deleted'
             }
@@ -103,8 +106,9 @@ function Set-BitbucketRepositoryReviewer {
         ConfirmImpact = 'High')]
     Param (
         [Parameter( ValueFromPipelineByPropertyName = $true,
-            HelpMessage = 'Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true,
@@ -119,11 +123,11 @@ function Set-BitbucketRepositoryReviewer {
         [string[]]$UUIDs
     )
     Process {
-        $existingUsers = Get-BitbucketRepositoryReviewer -Team $Team -RepoSlug $RepoSlug
+        $existingUsers = Get-BitbucketRepositoryReviewer -Workspace $Workspace -RepoSlug $RepoSlug
 
         if ($existingUsers.Count -eq 0) {
             foreach ($uuid in $UUIDs) {
-                Add-BitbucketRepositoryReviewer -Team $Team -RepoSlug $RepoSlug -UUID $uuid
+                Add-BitbucketRepositoryReviewer -Workspace $Workspace -RepoSlug $RepoSlug -UUID $uuid
             }
         }
         else {
@@ -135,7 +139,7 @@ function Set-BitbucketRepositoryReviewer {
 
             if ($missingUsers) {
                 foreach ($missingUser in $missingUsers) {
-                    Add-BitbucketRepositoryReviewer -Team $Team -RepoSlug $RepoSlug -UUID $missingUser
+                    Add-BitbucketRepositoryReviewer -Workspace $Workspace -RepoSlug $RepoSlug -UUID $missingUser
                 }
             }
 
@@ -144,7 +148,7 @@ function Set-BitbucketRepositoryReviewer {
 
             if ($extraUsers) {
                 foreach ($extraUser in $extraUsers) {
-                    Remove-BitbucketRepositoryReviewer -Team $Team -RepoSlug $RepoSlug -UUID $extraUser
+                    Remove-BitbucketRepositoryReviewer -Workspace $Workspace -RepoSlug $RepoSlug -UUID $extraUser
                 }
             }
         }

--- a/Atlassian.Bitbucket.Repository.psm1
+++ b/Atlassian.Bitbucket.Repository.psm1
@@ -2,21 +2,21 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 
 <#
     .SYNOPSIS
-        Returns all Repositories in the team.
+        Returns all Repositories in the workspace.
 
     .DESCRIPTION
-        Returns all the Bitbucket Repositories in the team, or all repositories in the specific project.
+        Returns all the Bitbucket Repositories in the workspace, or all repositories in the specific project.
 
     .EXAMPLE
         C:\PS> Get-BitbucketRepository
-        Returns all repositories for the currently selected team.
+        Returns all repositories for the currently selected workspace.
 
     .EXAMPLE
         C:\PS> Get-BitbucketRepository -ProjectKey 'KEY'
         Returns all repositories for the specified project.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -27,27 +27,29 @@ using module .\Atlassian.Bitbucket.Authentication.psm1
 function Get-BitbucketRepository {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Project key in Bitbucket')]
+        [Parameter( Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Project key in Bitbucket')]
         [string]$ProjectKey
     )
 
     Process {
-        $endpoint = "repositories/$Team"
+        $endpoint = "repositories/$Workspace"
 
-        if($RepoSlug){
+        if ($RepoSlug) {
             return Invoke-BitbucketAPI -Path "$endpoint/$RepoSlug"
-        }elseif($ProjectKey){
+        }
+        elseif ($ProjectKey) {
             # Filter to a specific project
             $endpoint += "?q=project.key=%22$ProjectKey%22"
         }
@@ -57,21 +59,21 @@ function Get-BitbucketRepository {
 
 <#
     .SYNOPSIS
-        Creates a new repositories in the team.
+        Creates a new repositories in the workspace.
 
     .DESCRIPTION
-        Creates a new Bitbucket repositories in the team, and in a specific project if specified.
+        Creates a new Bitbucket repositories in the workspace, and in a specific project if specified.
 
     .EXAMPLE
         C:\PS> New-BitbucketRepository -RepoSlug 'NewRepo'
-        Creates a new repository in Bitbucket called NewRepo.  Since a project wasn't specified the repository is automatically assigned to the oldest project in the team.
+        Creates a new repository in Bitbucket called NewRepo.  Since a project wasn't specified the repository is automatically assigned to the oldest project in the workspace.
 
     .EXAMPLE
         C:\PS> New-BitbucketRepository -RepoSlug 'NewRepo' -ProjectKey 'KEY'
         Creates a new repository in Bitbucket called NewRepo and puts it in the KEY project.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -95,68 +97,70 @@ function Get-BitbucketRepository {
         Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]
 #>
 function New-BitbucketRepository {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Specify a Friendly Name for the Repo')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Specify a Friendly Name for the Repo')]
         [ValidateNotNullOrEmpty()]
         [string]$Name,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Project key in Bitbucket')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Project key in Bitbucket')]
         [string]$ProjectKey,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Is the repo private?')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Is the repo private?')]
         [boolean]$Private = $true,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Description for the repo')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Description for the repo')]
         [string]$Description = '',
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Programming language used in the repo')]
-        [ValidateSet('java', 'javascript','python','ruby','php','powershell')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Programming language used in the repo')]
+        [ValidateSet('java', 'javascript', 'python', 'ruby', 'php', 'powershell')]
         [string]$Language = '',
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]')]
         [ValidateSet('allow_forks', 'no_public_forks', 'no_forks')]
         [string]$ForkPolicy = 'no_forks'
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug"
+        $endpoint = "repositories/$Workspace/$RepoSlug"
 
-        if($ProjectKey){
+        if ($ProjectKey) {
             $body = [ordered]@{
-                scm = 'git'
-                project = [ordered]@{
+                scm         = 'git'
+                project     = [ordered]@{
                     key = $ProjectKey
                 }
-                is_private = $Private
-                name = if ($Name) { $Name } else { $RepoSlug }
+                is_private  = $Private
+                name        = if ($Name) { $Name } else { $RepoSlug }
                 description = $Description
-                language = $Language
+                language    = $Language
                 fork_policy = $ForkPolicy
             } | ConvertTo-Json -Depth 2 -Compress
-        }else{
+        }
+        else {
             $body = [ordered]@{
-                scm = 'git'
-                is_private = $Private
-                name = if ($Name) { $Name } else { $RepoSlug }
+                scm         = 'git'
+                is_private  = $Private
+                name        = if ($Name) { $Name } else { $RepoSlug }
                 description = $Description
-                language = $Language
+                language    = $Language
                 fork_policy = $ForkPolicy
             } | ConvertTo-Json -Depth 2 -Compress
         }
 
-        if ($pscmdlet.ShouldProcess($RepoSlug, 'create')){
+        if ($pscmdlet.ShouldProcess($RepoSlug, 'create')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body  -Method Post
         }
     }
@@ -177,8 +181,8 @@ function New-BitbucketRepository {
         C:\PS> Set-BitbucketRepository -RepoSlug 'Repo' -ProjectKey 'KEY'
         Moves the repo to the Project 'KEY'
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -202,78 +206,79 @@ function New-BitbucketRepository {
         Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]
 #>
 function Set-BitbucketRepository {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Medium')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( HelpMessage='Set the Friendly Name of the Repository')]
+        [Parameter( HelpMessage = 'Set the Friendly Name of the Repository')]
         [ValidateNotNullOrEmpty()]
         [string]$Name,
-        [Parameter( HelpMessage='Project key in Bitbucket')]
+        [Parameter( HelpMessage = 'Project key in Bitbucket')]
         [string]$ProjectKey,
-        [Parameter( HelpMessage='Is the repo private?')]
+        [Parameter( HelpMessage = 'Is the repo private?')]
         [boolean]$Private,
-        [Parameter( HelpMessage='Description for the repo')]
+        [Parameter( HelpMessage = 'Description for the repo')]
         [string]$Description,
-        [Parameter( HelpMessage='Programming language used in the repo')]
-        [ValidateSet('java', 'javascript','python','ruby','php','powershell')]
+        [Parameter( HelpMessage = 'Programming language used in the repo')]
+        [ValidateSet('java', 'javascript', 'python', 'ruby', 'php', 'powershell')]
         [string]$Language,
-        [Parameter( HelpMessage='Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]')]
+        [Parameter( HelpMessage = 'Fork policy of the repo.  [allow_forks, no_public_forks, no_forks]')]
         [ValidateSet('allow_forks', 'no_public_forks', 'no_forks')]
         [string]$ForkPolicy
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug"
+        $endpoint = "repositories/$Workspace/$RepoSlug"
         $body = [ordered]@{}
 
-        if($ProjectKey){
+        if ($ProjectKey) {
             $body += [ordered]@{
                 project = [ordered]@{
                     key = $ProjectKey
                 }
             }
         }
-        if($Private){
+        if ($Private) {
             $body += [ordered]@{
                 is_private = $Private
             }
         }
-        if ($Name){
+        if ($Name) {
             $body += [ordered]@{
                 name = $Name
             }
         }
-        if($Description){
+        if ($Description) {
             $body += [ordered]@{
                 description = $Description
             }
         }
-        if($Language){
+        if ($Language) {
             $body += [ordered]@{
                 language = $Language
             }
         }
-        if($ForkPolicy){
+        if ($ForkPolicy) {
             $body += [ordered]@{
                 fork_policy = $ForkPolicy
             }
         }
-        if($body.Count -eq 0){
+        if ($body.Count -eq 0) {
             throw "No settings provided to update"
         }
 
         $body = $body | ConvertTo-Json -Depth 2 -Compress
 
-        if ($pscmdlet.ShouldProcess($RepoSlug, 'update')){
+        if ($pscmdlet.ShouldProcess($RepoSlug, 'update')) {
             return Invoke-BitbucketAPI -Path $endpoint -Body $body -Method Put
         }
     }
@@ -294,8 +299,8 @@ function Set-BitbucketRepository {
         C:\PS> Remove-BitbucketRepository -RepoSlug 'Repo1' -Redirect 'NewURL'
         Deletes the repository named Repo1 and leaves a redirect message for future visitors.
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -304,31 +309,32 @@ function Set-BitbucketRepository {
         If a repository has been moved to a new location, use this parameter to show users a friendly message in the Bitbucket UI that the repository has moved to a new location. However, a GET to this endpoint will still return a 404.
 #>
 function Remove-BitbucketRepository {
-    [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='High')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Redirect string')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Redirect string')]
         [string]$Redirect
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug"
+        $endpoint = "repositories/$Workspace/$RepoSlug"
 
-        if($Redirect){
+        if ($Redirect) {
             $endpoint += "?redirect_to=$Redirect"
         }
 
-        if ($pscmdlet.ShouldProcess($RepoSlug, 'permanently delete')){
+        if ($pscmdlet.ShouldProcess($RepoSlug, 'permanently delete')) {
             return Invoke-BitbucketAPI -Path $endpoint -Method Delete
         }
     }
@@ -342,7 +348,7 @@ function Remove-BitbucketRepository {
         Creates a branch in the specified repository. If no parent is specified, branch will be created from the latest commit of the default branch.
 
     .EXAMPLE
-        C:\PS> Add-BitBucketRepositoryBranch -Branch 'NewBranch' -Team 'MyTeam' -RepoSlug 'Repo1'
+        C:\PS> Add-BitBucketRepositoryBranch -Branch 'NewBranch' -Workspace 'MyWorkspace' -RepoSlug 'Repo1'
         Adds new branch from the last commit of the default branch
 
     .EXAMPLE
@@ -353,8 +359,8 @@ function Remove-BitbucketRepository {
         C:\PS> Add-BitBucketRepositoryBranch -Branch 'NewBranch' -Message 'Create new branch'
         Adds new branch with specified commit message
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -371,31 +377,32 @@ function Remove-BitbucketRepository {
 function Add-BitbucketRepositoryBranch {
     [CmdletBinding()]
     param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter( Mandatory=$true,
-                    Position=1,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the branch to create.')]
+        [Parameter( Mandatory = $true,
+            Position = 1,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the branch to create.')]
         [string]$Branch,
-        [Parameter(HelpMessage='Hash of the commit to create the branch from.')]
+        [Parameter(HelpMessage = 'Hash of the commit to create the branch from.')]
         [string]$Parent,
-        [Parameter(HelpMessage='Commit message for the new branch.')]
+        [Parameter(HelpMessage = 'Commit message for the new branch.')]
         [string]$Message
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/src/"
+        $endpoint = "repositories/$Workspace/$RepoSlug/src/"
 
-        $body = [ordered]@{branch=$Branch}
+        $body = [ordered]@{branch = $Branch }
 
         if ($Parent) {
             $body.Add("parents", $parent)
@@ -424,8 +431,8 @@ function Add-BitbucketRepositoryBranch {
         C:\ PS> Get-BitbucketRepositoryBranch -RepoSlug 'repo' -Name 'feature'
         Returns all the branches in the Repository named repo with the word feature in their name
 
-    .PARAMETER Team
-        Name of the team in Bitbucket.  Defaults to selected team if not provided.
+    .PARAMETER Workspace
+        Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.
 
     .PARAMETER RepoSlug
         Name of the repo in Bitbucket.
@@ -436,22 +443,23 @@ function Add-BitbucketRepositoryBranch {
 function Get-BitbucketRepositoryBranch {
     [CmdletBinding()]
     param (
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter( Mandatory=$true,
-                    Position=0,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='The repository slug.')]
+        [Parameter( ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+        [Alias("Team")]
+        [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+        [Parameter( Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            HelpMessage = 'The repository slug.')]
         [Alias('Slug')]
         [string]$RepoSlug,
-        [Parameter(HelpMessage='Search for the specified branch name')]
+        [Parameter(HelpMessage = 'Search for the specified branch name')]
         [string]$Name
     )
 
     Process {
-        $endpoint = "repositories/$Team/$RepoSlug/refs/branches?q=name~`"$Name`""
+        $endpoint = "repositories/$Workspace/$RepoSlug/refs/branches?q=name~`"$Name`""
 
         return Invoke-BitbucketAPI -Path $endpoint -Paginated
     }

--- a/Atlassian.Bitbucket.User.psm1
+++ b/Atlassian.Bitbucket.User.psm1
@@ -1,111 +1,118 @@
 using module .\Atlassian.Bitbucket.Authentication.psm1
 <#
 .Synopsis
-   Gets the list of users with access to at least one repository for the team specified.
+   Gets the list of users with access to at least one repository for the workspace specified.
 .DESCRIPTION
-   This function returns a list of all the users with access to at least one repository given the team specified. If no team is specified,
-   defaults to the selected team.
+   This function returns a list of all the users with access to at least one repository given the workspace specified. If no workspace is specified,
+   defaults to the selected workspace.
 .EXAMPLE
    Get-BitbucketUser
-   Returns a list of users of the default team.
+   Returns a list of users of the default workspace.
 .EXAMPLE
-   Get-BitbucketUser -Team $Team
-   Returns a list of users of the specified team.
+   Get-BitbucketUser -Workspace $Workspace
+   Returns a list of users of the specified workspace.
 #>
 function Get-BitbucketUser {
-    [CmdletBinding()]
-    param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam)
-    )
+   [CmdletBinding()]
+   param(
+      [Parameter( ValueFromPipelineByPropertyName = $true,
+         HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+      [Alias("Team")]
+      [string]$Workspace = (Get-BitbucketSelectedWorkspace)
+   )
 
-    Process {
-        $endpoint = "users/$Team/members"
-        return Invoke-BitbucketAPI -Path $endpoint -Paginated
-    }
+   Process {
+      $endpoint = "workspaces/$Workspace/members"
+      return Invoke-BitbucketAPI -Path $endpoint -Paginated
+   }
 }
 <#
 .Synopsis
    Gets the list of users associated to the group slug specified.
 .DESCRIPTION
-   This function returns a list of all the users associated to the group slug specified. If no team is specified,
-   defaults to the selected team.
+   This function returns a list of all the users associated to the group slug specified. If no workspace is specified,
+   defaults to the selected workspace.
 .EXAMPLE
    Get-BitbucketUsersByGroup -GroupSlug $GroupSlug
-   Returns a list of users associated to the specified group slug for the default team.
+   Returns a list of users associated to the specified group slug for the default workspace.
 .EXAMPLE
-   Get-BitbucketUsersByGroup -Team $Team -GroupSlug $GroupSlug
-   Returns a list of users associated to the specified group slug for the specified team.
+   Get-BitbucketUsersByGroup -Workspace $Workspace -GroupSlug $GroupSlug
+   Returns a list of users associated to the specified group slug for the specified workspace.
 #>
 function Get-BitbucketUsersByGroup {
-    [CmdletBinding()]
-    param(
-        [Parameter( ValueFromPipelineByPropertyName=$true,
-                    HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-        [string]$Team = (Get-BitbucketSelectedTeam),
-        [Parameter (HelpMessage='The group slug')]
-        [string]$GroupSlug
-    )
+   [CmdletBinding()]
+   [Obsolete('No longer supported by Atlassian')]
+   param(
+      [Parameter( ValueFromPipelineByPropertyName = $true,
+         HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+      [Alias("Team")]
+      [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+      [Parameter (HelpMessage = 'The group slug')]
+      [string]$GroupSlug
+   )
 
-    Process {
-        $endpoint = "groups/$Team/$GroupSlug/members"
-        return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0'
-    }
+   Process {
+      $endpoint = "groups/$Workspace/$GroupSlug/members"
+      return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0'
+   }
 }
 <#
 .Synopsis
    Gets the list of user groups.
 .DESCRIPTION
-   This function returns a list of all the user groups. If no team is specified,
-   defaults to the selected team.
+   This function returns a list of all the user groups. If no workspace is specified,
+   defaults to the selected workspace.
 .EXAMPLE
    Get-BitbucketGroup
-   Returns a list of groups for the default team.
+   Returns a list of groups for the default workspace.
 .EXAMPLE
-   Get-BitbucketGroup -Team $Team
-   Returns a list of groups for the specified team.
+   Get-BitbucketGroup -Workspace $Workspace
+   Returns a list of groups for the specified workspace.
 #>
 function Get-BitbucketGroup {
    [CmdletBinding()]
+   [Obsolete('No longer supported by Atlassian')]
    param(
-       [Parameter( ValueFromPipelineByPropertyName=$true,
-                   HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-       [string]$Team = (Get-BitbucketSelectedTeam)
+      [Parameter( ValueFromPipelineByPropertyName = $true,
+         HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+      [Alias("Team")]
+      [string]$Workspace = (Get-BitbucketSelectedWorkspace)
    )
 
    Process {
-       $endpoint = "groups/$Team"
-       return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0'
+      $endpoint = "groups/$Workspace"
+      return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0'
    }
 }
 <#
 .Synopsis
    Add a user to a group
 .DESCRIPTION
-   This function adds an existing user to an existing group. If no team is specified,
-   defaults to the selected team.
+   This function adds an existing user to an existing group. If no workspace is specified,
+   defaults to the selected workspace.
 .EXAMPLE
    Add-BitbucketUserToGroup -GroupSlug $GroupSlug -UserUuid $UserUuid
-   Adds user to group within the default team.
+   Adds user to group within the default workspace.
 .EXAMPLE
-   Add-BitbucketUserToGroup -GroupSlug $GroupSlug -UserUuid $UserUuid -Team $Team
-   Adds user to group within the specified team.
+   Add-BitbucketUserToGroup -GroupSlug $GroupSlug -UserUuid $UserUuid -Workspace $Workspace
+   Adds user to group within the specified workspace.
 #>
 function Add-BitbucketUserToGroup {
    [CmdletBinding()]
+   [Obsolete('No longer supported by Atlassian')]
    param(
-       [Parameter( ValueFromPipelineByPropertyName=$true,
-                   HelpMessage='Name of the team in Bitbucket.  Defaults to selected team if not provided.')]
-       [string]$Team = (Get-BitbucketSelectedTeam),
-       [Parameter (HelpMessage='The group slug')]
-       [string]$GroupSlug,
-       [Parameter (HelpMessage='The user UUID')]
-       [string]$UserUuid
+      [Parameter( ValueFromPipelineByPropertyName = $true,
+         HelpMessage = 'Name of the workspace in Bitbucket.  Defaults to selected workspace if not provided.')]
+      [Alias("Team")]
+      [string]$Workspace = (Get-BitbucketSelectedWorkspace),
+      [Parameter (HelpMessage = 'The group slug')]
+      [string]$GroupSlug,
+      [Parameter (HelpMessage = 'The user UUID')]
+      [string]$UserUuid
    )
 
    Process {
-       $endpoint = "groups/$Team/$GroupSlug/members/$UserUuid"
-       return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0' -Method 'Put'
+      $endpoint = "groups/$Workspace/$GroupSlug/members/$UserUuid"
+      return Invoke-BitbucketAPI -Path $endpoint -API_Version '1.0' -Method 'Put'
    }
 }

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.28.1'
+    ModuleVersion     = '0.29.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')
@@ -101,7 +101,7 @@
         'Get-BitbucketPullRequestComment',
         'Get-BitbucketRepository',
         'Get-BitbucketRepositoryBranch',
-	'Get-BitbucketRepositoryBranchModel',
+        'Get-BitbucketRepositoryBranchModel',
         'Get-BitbucketRepositoryBranchRestriction',
         'Get-BitbucketRepositoryDeployment',
         'Get-BitbucketRepositoryEnvironment',
@@ -109,9 +109,9 @@
         'Get-BitbucketRepositoryGroupPermission',
         'Get-BitbucketRepositoryReviewer',
         'Get-BitbucketRepositoryVariable',
-        'Get-BitbucketSelectedTeam',
+        'Get-BitbucketSelectedWorkspace',
         'Get-BitbucketGroup',
-        'Get-BitbucketTeam',
+        'Get-BitbucketWorkspace',
         'Get-BitbucketUser',
         'Get-BitbucketUsersByGroup',
         'New-BitbucketLogin',
@@ -133,7 +133,7 @@
         'Remove-BitbucketRepositoryReviewer',
         'Remove-BitbucketRepositoryVariable',
         'Save-BitbucketLogin',
-        'Select-BitbucketTeam',
+        'Select-BitbucketWorkspace',
         'Set-BitbucketRepository',
         'Set-BitbucketRepositoryBranchModel',
         'Set-BitbucketRepositoryBranchRestriction',
@@ -150,7 +150,13 @@
     VariablesToExport = @()
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport   = @('Login-Bitbucket')
+    # Team aliases point to workspace functions. https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/
+    AliasesToExport   = @(
+        'Get-BitbucketTeam',
+        'Get-BitbucketSelectedTeam',
+        'Login-Bitbucket',
+        'Select-BitbucketTeam'
+    )
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.28.0'
+    ModuleVersion     = '0.28.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ _These will be removed in the next major release_
 
 - N/A
 
-## 0.28.1
-- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model`
+## 0.29.0
+- Updated team cmdlets to workspace while retaining old names with alias https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/
+- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model
 
 ## 0.28.0
 - Added `Add-BitbucketRepositoryBranch` to create a new branch in a repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ _These will be removed in the next major release_
 
 - N/A
 
+## 0.28.1
+- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model`
+
 ## 0.28.0
 - Added `Add-BitbucketRepositoryBranch` to create a new branch in a repo
 - Added `Get-BitbucketRepositoryBranch` to return branches in a repo

--- a/Classes/Atlassian.Bitbucket.Auth.psm1
+++ b/Classes/Atlassian.Bitbucket.Auth.psm1
@@ -7,7 +7,7 @@ class BitbucketAuth {
     # Parameters
     [PSCredential]$Credential
     [Object]$User
-    [String]$Team
+    [String]$Workspace
     [String]$AuthType
 
     # OAuth Parameters
@@ -31,7 +31,7 @@ class BitbucketAuth {
     }
 
     # OAuth 2 Instantiator
-    static [BitbucketAuth] NewInstance([PSCredential]$AtlassianCredential, [PSCredential]$OAuthConsumer){
+    static [BitbucketAuth] NewInstance([PSCredential]$AtlassianCredential, [PSCredential]$OAuthConsumer) {
         # Remove existing instance
         [BitbucketAuth]::ClearInstance()
 
@@ -47,7 +47,7 @@ class BitbucketAuth {
         return [BitbucketAuth]::instance
     }
 
-    static [Void] ClearInstance(){
+    static [Void] ClearInstance() {
         [BitbucketAuth]::instance = $null
     }
 
@@ -55,12 +55,14 @@ class BitbucketAuth {
     static [BitbucketAuth] GetInstance() {
         if ($null -eq [BitbucketAuth]::instance) {
             # Try loading saved settings
-            if([BitbucketAuth]::load()){
+            if ([BitbucketAuth]::load()) {
                 return [BitbucketAuth]::instance
-            }else{
+            }
+            else {
                 throw 'You are not logged in.  Please login with Login-Bitbucket.'
             }
-        }else{
+        }
+        else {
             return [BitbucketAuth]::instance
         }
     }
@@ -83,13 +85,13 @@ class BitbucketAuth {
         switch ($this.AuthType) {
             'Basic' {
                 $basicAuth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $this.Credential.GetNetworkCredential().UserName, $this.Credential.GetNetworkCredential().Password)))
-                return @{Authorization = "Basic $basicAuth"}
+                return @{Authorization = "Basic $basicAuth" }
             }
             'Bearer' {
-                if($this.Token.expires -le (Get-Date)){
+                if ($this.Token.expires -le (Get-Date)) {
                     $this.GetAuthToken()
                 }
-                return @{Authorization = "Bearer $($this.Token.accessToken)"}
+                return @{Authorization = "Bearer $($this.Token.accessToken)" }
             }
             Default {
                 Throw "Unknown Authentication Type: $($this.AuthType)"
@@ -102,14 +104,14 @@ class BitbucketAuth {
     hidden [Void] GetAuthToken() {
         $body = @{
             grant_type = 'password'
-            username = $this.AtlassianCredential.GetNetworkCredential().UserName
-            password = $this.AtlassianCredential.GetNetworkCredential().Password
+            username   = $this.AtlassianCredential.GetNetworkCredential().UserName
+            password   = $this.AtlassianCredential.GetNetworkCredential().Password
         }
 
         # Generate the Authentication Header using the ClientID / Secret
         # Not using -Authentication as older versions of Invoke-RestMethod don't support it
         $basicAuth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $this.OAuthConsumer.GetNetworkCredential().UserName, $this.OAuthConsumer.GetNetworkCredential().Password)))
-        $header = @{Authorization = "Basic $basicAuth"}
+        $header = @{Authorization = "Basic $basicAuth" }
 
         # Get the token from Bitbucket
         $response = Invoke-RestMethod 'https://bitbucket.org/site/oauth2/access_token' -Method Post -Headers $header -Body $body
@@ -121,43 +123,43 @@ class BitbucketAuth {
             $parts = $scope -split ':'
 
             $scopes += [PSCustomObject]@{
-                Name = $parts[0]
+                Name       = $parts[0]
                 Permission = $parts[1]
             }
         }
 
         # Store the token
         $this.Token = [PSCustomObject]@{
-            accessToken = $response.access_token
-            scopes = $scopes
-            expires = (Get-Date).AddSeconds($response.expires_in)
+            accessToken  = $response.access_token
+            scopes       = $scopes
+            expires      = (Get-Date).AddSeconds($response.expires_in)
             refreshToken = $response.refresh_token
-            tokenType = $response.token_type
+            tokenType    = $response.token_type
         }
     }
 
     # Save the settings to the local system
-    [void] Save(){
-        if(!(Test-Path([BitbucketSettings]::SAVE_DIR))){
+    [void] Save() {
+        if (!(Test-Path([BitbucketSettings]::SAVE_DIR))) {
             New-Item -Type Directory -Path ([BitbucketSettings]::SAVE_DIR)
         }
 
         # Create a filtered object to save
         $Save = [PSCustomObject]@{
-            User = $this.User
-            Team = $this.Team
-            Credential = $this.Credential
+            User                = $this.User
+            Workspace           = $this.Workspace
+            Credential          = $this.Credential
             AtlassianCredential = $this.AtlassianCredential
-            OAuthConsumer = $this.OAuthConsumer
-            AuthType = $this.AuthType
+            OAuthConsumer       = $this.OAuthConsumer
+            AuthType            = $this.AuthType
         }
 
         $Save | Export-CliXml -Path ([BitbucketSettings]::SAVE_PATH)  -Encoding 'utf8' -Force
     }
 
     # Load Saved Credentials
-    hidden static [BitbucketAuth] Load(){
-        if(Test-Path([BitbucketSettings]::SAVE_PATH)){
+    hidden static [BitbucketAuth] Load() {
+        if (Test-Path([BitbucketSettings]::SAVE_PATH)) {
             try {
                 $Import = Import-CliXml -Path ([BitbucketSettings]::SAVE_PATH)
             }
@@ -168,7 +170,13 @@ class BitbucketAuth {
             $Auth = [BitbucketAuth]::new()
 
             $Auth.User = $Import.User
-            $Auth.Team = $Import.Team
+
+            # Support migration from team to workspace
+            if($import.Team){
+                $Auth.Workspace = $Import.Team
+            } else {
+                $Auth.Workspace = $Import.Workspace
+            }
             $Auth.Credential = $Import.Credential
             $Auth.AtlassianCredential = $Import.AtlassianCredential
             $Auth.OAuthConsumer = $Import.OAuthConsumer

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Login-Bitbucket -AtlassianCredential $Cred -OAuthConsumer $OAuth
 
 Use `Login-Bitbucket -Save` when logging in or `Save-BitbucketLogin` at any time to save the information to an encrypted file that will be automatically loaded when you start a new session.
 
-#### Teams
+#### Workspaces
 
-The module will automatically select your team if you have 1 when logging in or prompt you to choose from a list of teams. Cmdlets will default to the team selected unless specified. If you wish to change the team run `Select-BitbucketTeam`. If you want to save the change run `Save-BitbucketLogin` again.
+The module will automatically select your workspace if you have 1 when logging in or prompt you to choose from a list of workspaces. Cmdlets will default to the workspace selected unless specified. If you wish to change the workspace run `Select-BitbucketWorkspace`. If you want to save the change run `Save-BitbucketLogin` again.
 
 ### CMDLETs
 
@@ -73,12 +73,12 @@ To get more information on each cmdlet run `Get-Help <CMDLET Name>`
 #### Authentication CMDLETs
 
 - `Get-BitbucketLogin`
-- `Get-BitbucketSelectedTeam`
-- `Get-BitbucketTeam`
+- `Get-BitbucketSelectedWorkspace`
+- `Get-BitbucketWorkspace`
 - `New-BitbucketLogin`
 - `Remove-BitbucketLogin`
 - `Save-BitbucketLogin`
-- `Select-BitbucketTeam`
+- `Select-BitbucketWorkspace`
 
 #### Pipeline CMDLETs
 

--- a/Tests/Authentication.Tests/Get-BitbucketWorkspace.Tests.ps1
+++ b/Tests/Authentication.Tests/Get-BitbucketWorkspace.Tests.ps1
@@ -1,0 +1,42 @@
+Import-Module '.\Atlassian.Bitbucket.Authentication.psm1' -Force
+
+Describe 'Get-BitbucketWorkspace' {
+    Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Authentication { 
+        $Response = New-Object PSObject -Property @{
+            values = 'Value1'
+        }
+        return $Response
+    }
+    
+    Context 'Get-BitbucketWorkspace' {
+        $result = Get-BitbucketWorkspace
+
+        It 'Uses default GET Method' {
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Authentication -ParameterFilter {
+                $Method -eq $null
+            }
+        }
+
+        It 'Has a valid path' {
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Authentication -ParameterFilter {
+                $Path -eq "workspaces?role=member"
+            }
+        }
+
+        It 'Has no body'{
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Authentication -ParameterFilter {
+                $Body -eq $null
+            }
+        }
+
+        It 'Is not paginated' {
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Authentication -ParameterFilter {
+                $Paginated -eq $null
+            }
+        }
+
+        It 'Returns value' {
+            $result | Should -Be 'Value1'
+        }
+    }
+}

--- a/Tests/BranchModel.Tests/Get-BitbucketRepositoryBranchModel.Tests.ps1
+++ b/Tests/BranchModel.Tests/Get-BitbucketRepositoryBranchModel.Tests.ps1
@@ -8,11 +8,11 @@ Describe 'Get-BitbucketRepositoryBranchModel' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
 
     Context 'Get Branching Model' {
-        Get-BitbucketRepositoryBranchModel -Team $Team -RepoSlug $Repo
+        Get-BitbucketRepositoryBranchModel -Workspace $Workspace -RepoSlug $Repo
         
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
@@ -22,11 +22,11 @@ Describe 'Get-BitbucketRepositoryBranchModel' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branching-model"
+                $Path -eq "repositories/$Workspace/$Repo/branching-model"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
                 $Body -eq $null
             }

--- a/Tests/BranchModel.Tests/Set-BitbucketRepositoryBranchModel.Tests.ps1
+++ b/Tests/BranchModel.Tests/Set-BitbucketRepositoryBranchModel.Tests.ps1
@@ -8,17 +8,17 @@ Describe 'Set-BitbucketRepositoryBranchModel' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $TestBody = [ordered]@{
         development = [ordered]@{
-            name = $null
+            name           = $null
             use_mainbranch = $true
         }
     } | ConvertTo-Json -Depth 2 -Compress
 
     Context 'Set Branching Model' {
-        Set-BitbucketRepositoryBranchModel -Team $Team -RepoSlug $Repo -Branch 'development' -UseMainBranch
+        Set-BitbucketRepositoryBranchModel -Workspace $Workspace -RepoSlug $Repo -Branch 'development' -UseMainBranch
         
         It 'Uses PUT Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
@@ -28,11 +28,11 @@ Describe 'Set-BitbucketRepositoryBranchModel' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branching-model/settings"
+                $Path -eq "repositories/$Workspace/$Repo/branching-model/settings"
             }
         }
 
-        It 'Has correct body'{
+        It 'Has correct body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchModel -ParameterFilter {
                 $Body -eq $TestBody
             }

--- a/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -8,12 +8,12 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
 
     Context 'Create new Glob based branch restriction' {
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
-        Add-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Add-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Uses POST Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
@@ -23,11 +23,11 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branch-restrictions"
+                $Path -eq "repositories/$Workspace/$Repo/branch-restrictions"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 ($MergeCheck | Select-Object -ExcludeProperty branch_type | ConvertTo-Json -Depth 2 -Compress) -eq $Body
             }
@@ -42,7 +42,7 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
     Context 'Create new branch_model based branch restriction' {
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -BranchType 'development' -Value 2
-        Add-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Add-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Uses POST Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
@@ -52,11 +52,11 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branch-restrictions"
+                $Path -eq "repositories/$Workspace/$Repo/branch-restrictions"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 ($MergeCheck | ConvertTo-Json -Depth 2 -Compress) -eq $Body
             }

--- a/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -1,7 +1,7 @@
 Import-Module '.\Atlassian.Bitbucket.Repository.BranchRestriction.psm1' -Force
 
 Describe 'Add-BitbucketRepositoryBranchRestriction' {
-    Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
+    Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction {
         $Response = New-Object PSObject -Property @{
             id = (New-Guid).Guid
         }
@@ -10,7 +10,7 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
     $Team = 'T'
     $Repo = 'R'
-    
+
     Context 'Create new Glob based branch restriction' {
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
         Add-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
@@ -30,6 +30,12 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
         It 'Has a valid body'{
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 ($MergeCheck | Select-Object -ExcludeProperty branch_type | ConvertTo-Json -Depth 2 -Compress) -eq $Body
+            }
+        }
+
+        It "Removes the branch_type property when branch_match_kind equals 'glob'" {
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
+                $null -eq ($Body | ConvertFrom-Json -Depth 3).branch_match_kind
             }
         }
     }

--- a/Tests/BranchRestriction.Tests/Get-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Get-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -3,17 +3,17 @@ Import-Module '.\Atlassian.Bitbucket.Repository.BranchRestriction.psm1' -Force
 Describe 'Get-BitbucketRepositoryBranchRestriction' {
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
         $Response = New-Object PSObject -Property @{
-            id = 123
+            id   = 123
             kind = 'delete'
         }
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Get restrictions' {
-        Get-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo
+        Get-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo
 
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
@@ -23,11 +23,11 @@ Describe 'Get-BitbucketRepositoryBranchRestriction' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branch-restrictions/"
+                $Path -eq "repositories/$Workspace/$Repo/branch-restrictions/"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 $Body -eq $null
             }

--- a/Tests/BranchRestriction.Tests/Remove-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Remove-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -5,12 +5,12 @@ Describe 'Remove-BitbucketRepositoryBranchRestriction' {
         return $null
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $ID = 123
     
     Context 'Remove Branch Restriction' {
-        Remove-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -RestrictionID $ID -Confirm:$false
+        Remove-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -RestrictionID $ID -Confirm:$false
 
         It 'Uses DELETE Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
@@ -20,11 +20,11 @@ Describe 'Remove-BitbucketRepositoryBranchRestriction' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/branch-restrictions/$ID"
+                $Path -eq "repositories/$Workspace/$Repo/branch-restrictions/$ID"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 $Body -eq $null
             }
@@ -36,17 +36,17 @@ Describe 'Remove-BitbucketRepositoryBranchRestriction' {
             id = 123
         }
 
-        $Restriction | Remove-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Confirm:$false
+        $Restriction | Remove-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Confirm:$false
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $Path -eq "repositories/$Team/$($Repo)/branch-restrictions/$ID"
+                $Path -eq "repositories/$Workspace/$($Repo)/branch-restrictions/$ID"
             }
         }
     }
 
     Context 'Supports WhatIf' {
-        Remove-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -RestrictionID $ID -WhatIf
+        Remove-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -RestrictionID $ID -WhatIf
 
         It 'Does not call the mock' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -Exactly 0

--- a/Tests/BranchRestriction.Tests/Set-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Set-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -4,23 +4,23 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
     Mock Add-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { }
     Mock Remove-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Matching Glob Restriction' {
         Mock Get-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
             return New-Object PSObject -Property @{
-                id = 123
-                kind = 'require_approvals_to_merge'
-                pattern = 'master'
-                value = 2
+                id                = 123
+                kind              = 'require_approvals_to_merge'
+                pattern           = 'master'
+                value             = 2
                 branch_match_kind = 'glob'
-                type = 'branchrestriction'
+                type              = 'branchrestriction'
             } | ConvertTo-BranchRestriction
         }
 
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
-        Set-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Set-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Does not add restriction' {
             Assert-MockCalled Add-BitbucketRepositoryBranchRestriction -Exactly 0 -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction
@@ -34,18 +34,18 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
     Context 'Matching branching_model Restriction' {
         Mock Get-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
             return New-Object PSObject -Property @{
-                id = 123
-                kind = 'require_approvals_to_merge'
-                pattern = ''
-                value = 2
+                id                = 123
+                kind              = 'require_approvals_to_merge'
+                pattern           = ''
+                value             = 2
                 branch_match_kind = 'branching_model'
-                branch_type = 'development'
-                type = 'branchrestriction'
+                branch_type       = 'development'
+                type              = 'branchrestriction'
             } | ConvertTo-BranchRestriction
         }
 
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -BranchType 'development' -Value 2
-        Set-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Set-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Does not add restriction' {
             Assert-MockCalled Add-BitbucketRepositoryBranchRestriction -Exactly 0 -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction
@@ -58,19 +58,19 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
 
     Context 'Mismatched Restriction' {
         $response = New-Object PSObject -Property @{
-            id = 123
-            kind = 'require_approvals_to_merge'
-            pattern = 'production'
-            value = 2
+            id                = 123
+            kind              = 'require_approvals_to_merge'
+            pattern           = 'production'
+            value             = 2
             branch_match_kind = 'glob'
-            type = 'branchrestriction'
+            type              = 'branchrestriction'
         } | ConvertTo-BranchRestriction
         Mock Get-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
             return $response
         }.GetNewClosure()
         
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
-        Set-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Set-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Adds restriction' {
             Assert-MockCalled Add-BitbucketRepositoryBranchRestriction -Exactly 1 -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction
@@ -93,7 +93,7 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
         }
         
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
-        Set-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Set-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Adds restriction' {
             Assert-MockCalled Add-BitbucketRepositoryBranchRestriction -Exactly 1 -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction
@@ -109,22 +109,22 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
 
     Context 'Complex Restrictions' {
         $response1 = New-Object PSObject -Property @{
-            id = 123
-            kind = 'require_approvals_to_merge'
-            pattern = 'master'
-            value = 2
+            id                = 123
+            kind              = 'require_approvals_to_merge'
+            pattern           = 'master'
+            value             = 2
             branch_match_kind = 'glob'
-            type = 'branchrestriction'
+            type              = 'branchrestriction'
         } | ConvertTo-BranchRestriction
     
         $response2 = New-Object PSObject -Property @{
-            id = 124
-            kind = 'delete'
-            pattern = 'master'
-            users = @()
-            groups = @()
+            id                = 124
+            kind              = 'delete'
+            pattern           = 'master'
+            users             = @()
+            groups            = @()
             branch_match_kind = 'glob'
-            type = 'branchrestriction'
+            type              = 'branchrestriction'
         } | ConvertTo-BranchRestriction
 
         Mock Get-BitbucketRepositoryBranchRestriction -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction {
@@ -135,16 +135,16 @@ Describe 'Set-BitbucketRepositoryBranchRestriction' {
         $MergeCheck += New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind $response1.kind -Pattern $response1.pattern -Value $response1.value
         $MergeCheck += New-BitbucketRepositoryBranchRestrictionPermissionCheck -Kind 'push' -BranchType 'hotfix' -UUID '{12a1a123-a1ab-1234-a12a-1abc12345a12}'
         $MergeCheck += New-Object PSObject -Property @{
-            id = 124
-            kind = 'delete'
-            pattern = 'production'
-            users = @()
-            groups = @()
+            id                = 124
+            kind              = 'delete'
+            pattern           = 'production'
+            users             = @()
+            groups            = @()
             branch_match_kind = 'glob'
-            type = 'branchrestriction'
+            type              = 'branchrestriction'
         } | ConvertTo-BranchRestriction
 
-        Set-BitbucketRepositoryBranchRestriction -Team $Team -RepoSlug $Repo -Restriction $MergeCheck
+        Set-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
 
         It 'Adds correct restriction' {
             Assert-MockCalled Add-BitbucketRepositoryBranchRestriction -Exactly 2 -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction

--- a/Tests/GroupPermission.Tests/Add-BitbucketRepositoryGroupPermission.Tests.ps1
+++ b/Tests/GroupPermission.Tests/Add-BitbucketRepositoryGroupPermission.Tests.ps1
@@ -9,22 +9,22 @@ Describe 'Add-BitbucketRepositoryGroupPermission' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $Group = 'G'
     $Privilege = 'read'
     
     Context 'Create new permission from pipeline' {
         $Permission = New-BitbucketRepositoryGroupPermission -GroupSlug $Group -Privilege $Privilege
-        $Permission | Add-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo
+        $Permission | Add-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
-                $Path -eq "group-privileges/$Team/$Repo/$Team/$Group"
+                $Path -eq "group-privileges/$Workspace/$Repo/$Workspace/$Group"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 $Privilege -eq $Body
             }
@@ -32,7 +32,7 @@ Describe 'Add-BitbucketRepositoryGroupPermission' {
     }
 
     Context 'Create new permission' {
-        Add-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -GroupSlug $Group -Privilege $Privilege
+        Add-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -GroupSlug $Group -Privilege $Privilege
 
         It 'Uses PUT Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
@@ -42,23 +42,23 @@ Describe 'Add-BitbucketRepositoryGroupPermission' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
-                $Path -eq "group-privileges/$Team/$Repo/$Team/$Group"
+                $Path -eq "group-privileges/$Workspace/$Repo/$Workspace/$Group"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 $Privilege -eq $Body
             }
         }
 
-        It 'Uses v1 API'{
+        It 'Uses v1 API' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 '1.0' -eq $API_Version
             }
         }
 
-        It 'Uses ContentType application/x-www-form-urlencoded'{
+        It 'Uses ContentType application/x-www-form-urlencoded' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 'application/x-www-form-urlencoded' -eq $ContentType
             }

--- a/Tests/GroupPermission.Tests/Get-BitbucketRepositoryGroupPermission.Tests.ps1
+++ b/Tests/GroupPermission.Tests/Get-BitbucketRepositoryGroupPermission.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module '.\Atlassian.Bitbucket.Repository.GroupPermission.psm1' -Force
 Describe 'Get-BitbucketRepositoryGroupPermission' {
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission { 
         $Response = New-Object PSObject -Property @{
-            group = @{
+            group     = @{
                 slug = 'group-slug'
             }
             privilege = 'read'
@@ -11,11 +11,11 @@ Describe 'Get-BitbucketRepositoryGroupPermission' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Get Permissions' {
-        Get-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo
+        Get-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo
 
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
@@ -25,11 +25,11 @@ Describe 'Get-BitbucketRepositoryGroupPermission' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
-                $Path -eq "group-privileges/$Team/$Repo"
+                $Path -eq "group-privileges/$Workspace/$Repo"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 $Body -eq $null
             }

--- a/Tests/GroupPermission.Tests/Remove-BitbucketRepositoryGroupPermission.Tests.ps1
+++ b/Tests/GroupPermission.Tests/Remove-BitbucketRepositoryGroupPermission.Tests.ps1
@@ -5,12 +5,12 @@ Describe 'Remove-BitbucketRepositoryGroupPermission' {
         return $null
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $GroupSlug = 'group-slug'
     
     Context 'Remove Group Permission' {
-        Remove-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -GroupSlug $GroupSlug
+        Remove-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -GroupSlug $GroupSlug
 
         It 'Uses DELETE Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
@@ -20,17 +20,17 @@ Describe 'Remove-BitbucketRepositoryGroupPermission' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
-                $Path -eq "group-privileges/$Team/$Repo/$Team/$GroupSlug"
+                $Path -eq "group-privileges/$Workspace/$Repo/$Workspace/$GroupSlug"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 $Body -eq $null
             }
         }
 
-        It 'Uses v1 API'{
+        It 'Uses v1 API' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
                 '1.0' -eq $API_Version
             }
@@ -42,17 +42,17 @@ Describe 'Remove-BitbucketRepositoryGroupPermission' {
             groupslug = $GroupSlug
         }
 
-        $Permission | Remove-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -Confirm:$false
+        $Permission | Remove-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -Confirm:$false
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -ParameterFilter {
-                $Path -eq "group-privileges/$Team/$Repo/$Team/$GroupSlug"
+                $Path -eq "group-privileges/$Workspace/$Repo/$Workspace/$GroupSlug"
             }
         }
     }
 
     Context 'Supports WhatIf' {
-        Remove-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -GroupSlug $GroupSlug -WhatIf
+        Remove-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -GroupSlug $GroupSlug -WhatIf
 
         It 'Does not call the mock' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.GroupPermission -Exactly 0

--- a/Tests/GroupPermission.Tests/Set-BitbucketRepositoryGroupPermission.Tests.ps1
+++ b/Tests/GroupPermission.Tests/Set-BitbucketRepositoryGroupPermission.Tests.ps1
@@ -6,17 +6,17 @@ Describe 'Set-BitbucketRepositoryGroupPermission' {
     Mock Add-BitbucketRepositoryGroupPermission -ModuleName Atlassian.Bitbucket.Repository.GroupPermission { }
     Mock Remove-BitbucketRepositoryGroupPermission -ModuleName Atlassian.Bitbucket.Repository.GroupPermission { }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Matching Permission' {
-        $response = [GroupPermissionV1]::New('group-slug','read')
+        $response = [GroupPermissionV1]::New('group-slug', 'read')
         Mock Get-BitbucketRepositoryGroupPermission -ModuleName Atlassian.Bitbucket.Repository.GroupPermission { 
             return $response
         }.GetNewClosure()
 
-        $Permission = [GroupPermissionV1]::New($response.groupslug,$response.privilege)
-        Set-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -Permissions $Permission
+        $Permission = [GroupPermissionV1]::New($response.groupslug, $response.privilege)
+        Set-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -Permissions $Permission
 
         It 'Does not add Permission' {
             Assert-MockCalled Add-BitbucketRepositoryGroupPermission -Exactly 0 -ModuleName Atlassian.Bitbucket.Repository.GroupPermission
@@ -28,13 +28,13 @@ Describe 'Set-BitbucketRepositoryGroupPermission' {
     }
 
     Context 'Mismatched Permission' {
-        $response = [GroupPermissionV1]::New('group-slug','read')
+        $response = [GroupPermissionV1]::New('group-slug', 'read')
         Mock Get-BitbucketRepositoryGroupPermission -ModuleName Atlassian.Bitbucket.Repository.GroupPermission { 
             return $response
         }.GetNewClosure()
         
-        $Permission = [GroupPermissionV1]::New($response.groupslug,'write')
-        Set-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -Permissions $Permission
+        $Permission = [GroupPermissionV1]::New($response.groupslug, 'write')
+        Set-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -Permissions $Permission
 
         It 'Adds Permission' {
             Assert-MockCalled Add-BitbucketRepositoryGroupPermission -Exactly 1 -ModuleName Atlassian.Bitbucket.Repository.GroupPermission
@@ -56,8 +56,8 @@ Describe 'Set-BitbucketRepositoryGroupPermission' {
             return $null
         }
         
-        $Permission = [GroupPermissionV1]::New('group-slug','write')
-        Set-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -Permission $Permission
+        $Permission = [GroupPermissionV1]::New('group-slug', 'write')
+        Set-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -Permission $Permission
 
         It 'Adds Permission' {
             Assert-MockCalled Add-BitbucketRepositoryGroupPermission -Exactly 1 -ModuleName Atlassian.Bitbucket.Repository.GroupPermission
@@ -72,18 +72,18 @@ Describe 'Set-BitbucketRepositoryGroupPermission' {
     }
 
     Context 'Complex Permissions' {
-        $response1 = [GroupPermissionV1]::New('group-admin','admin')
-        $response2 = [GroupPermissionV1]::New('group','read')
+        $response1 = [GroupPermissionV1]::New('group-admin', 'admin')
+        $response2 = [GroupPermissionV1]::New('group', 'read')
 
         Mock Get-BitbucketRepositoryGroupPermission -ModuleName Atlassian.Bitbucket.Repository.GroupPermission {
             return @($response1, $response2)
         }.GetNewClosure()
         
         $Permissions = @()
-        $Permissions += [GroupPermissionV1]::New('group-admin','admin')
-        $Permissions += [GroupPermissionV1]::New('group','write')
+        $Permissions += [GroupPermissionV1]::New('group-admin', 'admin')
+        $Permissions += [GroupPermissionV1]::New('group', 'write')
 
-        Set-BitbucketRepositoryGroupPermission -Team $Team -RepoSlug $Repo -Permission $Permissions
+        Set-BitbucketRepositoryGroupPermission -Workspace $Workspace -RepoSlug $Repo -Permission $Permissions
 
         It 'Adds correct Permission' {
             Assert-MockCalled Add-BitbucketRepositoryGroupPermission -Exactly 1 -ModuleName Atlassian.Bitbucket.Repository.GroupPermission

--- a/Tests/Pipeline.Tests/Enable-BitbucketPipelineConfig.Tests.ps1
+++ b/Tests/Pipeline.Tests/Enable-BitbucketPipelineConfig.Tests.ps1
@@ -1,16 +1,16 @@
 Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
 
 Describe "Enable-BitbucketPipelineConfig" {
-  $Team = 'T'
+  $Workspace = 'T'
   $Repo = 'R'
 
   Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline {}
 
-  Enable-BitbucketPipelineConfig -RepoSlug $Repo -Team $Team
+  Enable-BitbucketPipelineConfig -RepoSlug $Repo -Workspace $Workspace
 
   It 'Has a valid path' {
     Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
-        $Path -eq "repositories/$Team/$Repo/pipelines_config"
+      $Path -eq "repositories/$Workspace/$Repo/pipelines_config"
     }
   }
 

--- a/Tests/Pipeline.Tests/Get-BitbucketPipelineConfig.Tests.ps1
+++ b/Tests/Pipeline.Tests/Get-BitbucketPipelineConfig.Tests.ps1
@@ -1,16 +1,16 @@
 Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
 
 Describe "Enable-BitbucketPipelineConfig" {
-  $Team = 'T'
+  $Workspace = 'T'
   $Repo = 'R'
 
   Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline {}
 
-  Get-BitbucketPipelineConfig -RepoSlug $Repo -Team $Team
+  Get-BitbucketPipelineConfig -RepoSlug $Repo -Workspace $Workspace
 
   It 'Has a valid path' {
     Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
-        $Path -eq "repositories/$Team/$Repo/pipelines_config"
+      $Path -eq "repositories/$Workspace/$Repo/pipelines_config"
     }
   }
 

--- a/Tests/Pipeline.Tests/Get-BitbucketRepositoryVariable.Tests.ps1
+++ b/Tests/Pipeline.Tests/Get-BitbucketRepositoryVariable.Tests.ps1
@@ -1,16 +1,16 @@
 Import-Module '.\Atlassian.Bitbucket.Pipeline.Variable.psm1' -Force
 
 Describe "Get-BitbucketRepositoryVariable" {
-  $Team = 'T'
+  $Workspace = 'T'
   $Repo = 'R'
 
   Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable {}
 
-  Get-BitbucketRepositoryVariable -RepoSlug $Repo -Team $Team
+  Get-BitbucketRepositoryVariable -RepoSlug $Repo -Workspace $Workspace
 
   It 'Has a valid path' {
     Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable -ParameterFilter {
-        $Path -eq "repositories/$Team/$Repo/pipelines_config/variables/"
+      $Path -eq "repositories/$Workspace/$Repo/pipelines_config/variables/"
     }
   }
 

--- a/Tests/Pipeline.Tests/New-BitbucketRepositoryVariable.Tests.ps1
+++ b/Tests/Pipeline.Tests/New-BitbucketRepositoryVariable.Tests.ps1
@@ -1,18 +1,18 @@
 Import-Module '.\Atlassian.Bitbucket.Pipeline.Variable.psm1' -Force
 
 Describe "New-BitbucketRepositoryVariable" {
-  $Team = 'T'
+  $Workspace = 'T'
   $Repo = 'R'
   $Key = 'K'
   $Value = 'V'
 
   Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable {}
 
-  New-BitbucketRepositoryVariable -RepoSlug $Repo -Team $Team -Key $Key -Value $Value
+  New-BitbucketRepositoryVariable -RepoSlug $Repo -Workspace $Workspace -Key $Key -Value $Value
 
   It 'Has a valid path' {
     Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable -ParameterFilter {
-        $Path -eq "repositories/$Team/$Repo/pipelines_config/variables/"
+      $Path -eq "repositories/$Workspace/$Repo/pipelines_config/variables/"
     }
   }
 

--- a/Tests/Pipeline.Tests/Remove-BitbucketRepositoryVariable.Tests.ps1
+++ b/Tests/Pipeline.Tests/Remove-BitbucketRepositoryVariable.Tests.ps1
@@ -1,24 +1,24 @@
 Import-Module '.\Atlassian.Bitbucket.Pipeline.Variable.psm1' -Force
 
 Describe "Remove-BitbucketRepositoryVariable" {
-  $Team = 'T'
+  $Workspace = 'T'
   $Repo = 'R'
   $Key = 'K'
   $UUID = 'abc'
   Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable {}
   Mock Get-BitbucketRepositoryVariable -ModuleName Atlassian.Bitbucket.Pipeline.Variable {
     $Data = [pscustomobject]@{
-      key = 'K'
+      key  = 'K'
       uuid = 'abc'
     }
     Return $Data
   }
 
-  Remove-BitbucketRepositoryVariable -RepoSlug $Repo -Team $Team -Key $Key
+  Remove-BitbucketRepositoryVariable -RepoSlug $Repo -Workspace $Workspace -Key $Key
 
   It 'Has a valid path' {
     Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline.Variable -ParameterFilter {
-        $Path -eq "repositories/$Team/$Repo/pipelines_config/variables/abc"
+      $Path -eq "repositories/$Workspace/$Repo/pipelines_config/variables/abc"
     }
   }
 

--- a/Tests/Pipeline.Tests/Start-BitbucketPipeline.Tests.ps1
+++ b/Tests/Pipeline.Tests/Start-BitbucketPipeline.Tests.ps1
@@ -3,21 +3,21 @@ Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
 Describe 'Start-BitbucketPipeline' {
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline { 
         $Response = New-Object PSObject -Property @{
-            uuid = (New-Guid).Guid
+            uuid         = (New-Guid).Guid
             build_number = 1
-            state = New-Object PSObject -Property @{
+            state        = New-Object PSObject -Property @{
                 name = 'PENDING'
             }
         }
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $Branch = 'B'
     
     Context 'Default pipeline' {
-        Start-BitbucketPipeline -Team $Team -RepoSlug $Repo -Branch $Branch
+        Start-BitbucketPipeline -Workspace $Workspace -RepoSlug $Repo -Branch $Branch
 
         It 'Uses POST Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
@@ -27,94 +27,94 @@ Describe 'Start-BitbucketPipeline' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/pipelines/"
+                $Path -eq "repositories/$Workspace/$Repo/pipelines/"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
                 ([ordered]@{
-                    target = [ordered]@{
-                        type     = 'pipeline_ref_target'
-                        ref_type = 'branch'
-                        ref_name = $Branch
-                    }
-                } | ConvertTo-Json -Compress) -eq $Body
+                        target = [ordered]@{
+                            type     = 'pipeline_ref_target'
+                            ref_type = 'branch'
+                            ref_name = $Branch
+                        }
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
 
     Context 'No branch specified' {
-        Start-BitbucketPipeline -Team $Team -RepoSlug $Repo
+        Start-BitbucketPipeline -Workspace $Workspace -RepoSlug $Repo
 
-        It 'Defaults to master branch'{
+        It 'Defaults to master branch' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
                 ([ordered]@{
-                    target = [ordered]@{
-                        type     = 'pipeline_ref_target'
-                        ref_type = 'branch'
-                        ref_name = 'master'
-                    }
-                } | ConvertTo-Json -Compress) -eq $Body
+                        target = [ordered]@{
+                            type     = 'pipeline_ref_target'
+                            ref_type = 'branch'
+                            ref_name = 'master'
+                        }
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
 
     Context 'Custom Pipeline' {
         $Custom = 'C'
-        Start-BitbucketPipeline -Team $Team -RepoSlug $Repo -Branch $Branch -Custom $Custom
+        Start-BitbucketPipeline -Workspace $Workspace -RepoSlug $Repo -Branch $Branch -Custom $Custom
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
                 ([ordered]@{
-                    target = [ordered]@{
-                        type     = 'pipeline_ref_target'
-                        ref_type = 'branch'
-                        ref_name = $Branch
-                        selector = [ordered]@{
-                            type    = 'custom'
-                            pattern = $Custom
+                        target = [ordered]@{
+                            type     = 'pipeline_ref_target'
+                            ref_type = 'branch'
+                            ref_name = $Branch
+                            selector = [ordered]@{
+                                type    = 'custom'
+                                pattern = $Custom
+                            }
                         }
-                    }
-                } | ConvertTo-Json -Compress) -eq $Body
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
 
     Context 'Single Variable' {
-        $Var = @{var1 = 'value1'}
+        $Var = @{var1 = 'value1' }
 
-        Start-BitbucketPipeline -Team $Team -RepoSlug $Repo -Branch $Branch -Variables $Var
+        Start-BitbucketPipeline -Workspace $Workspace -RepoSlug $Repo -Branch $Branch -Variables $Var
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
                 ([ordered]@{
-                    target = [ordered]@{
-                        type     = 'pipeline_ref_target'
-                        ref_type = 'branch'
-                        ref_name = $Branch
-                    }
-                    variables = [array]$Var
-                } | ConvertTo-Json -Compress) -eq $Body
+                        target    = [ordered]@{
+                            type     = 'pipeline_ref_target'
+                            ref_type = 'branch'
+                            ref_name = $Branch
+                        }
+                        variables = [array]$Var
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
 
     Context 'Multiple Variables' {
-        $Var = @{var1 = 'value1'},@{var2 = 'value2'}
+        $Var = @{var1 = 'value1' }, @{var2 = 'value2' }
 
-        Start-BitbucketPipeline -Team $Team -RepoSlug $Repo -Branch $Branch -Variables $Var
+        Start-BitbucketPipeline -Workspace $Workspace -RepoSlug $Repo -Branch $Branch -Variables $Var
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
                 ([ordered]@{
-                    target = [ordered]@{
-                        type     = 'pipeline_ref_target'
-                        ref_type = 'branch'
-                        ref_name = $Branch
-                    }
-                    variables = $Var
-                } | ConvertTo-Json -Compress) -eq $Body
+                        target    = [ordered]@{
+                            type     = 'pipeline_ref_target'
+                            ref_type = 'branch'
+                            ref_name = $Branch
+                        }
+                        variables = $Var
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }

--- a/Tests/Pipeline.Tests/Wait-BitbucketPipeline.Tests.ps1
+++ b/Tests/Pipeline.Tests/Wait-BitbucketPipeline.Tests.ps1
@@ -3,16 +3,16 @@ Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
 Describe 'Wait-BitbucketPipeline' {
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline { 
         $Response = New-Object PSObject -Property @{
-            uuid = (New-Guid).Guid
+            uuid         = (New-Guid).Guid
             build_number = 1
-            state = New-Object PSObject -Property @{
+            state        = New-Object PSObject -Property @{
                 name = 'COMPLETED'
             }
         }
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     
     Context 'Pipeline Input from Start-BitbucketPipeline' {
         $Pipeline = New-Object PSObject -Property @{
@@ -22,11 +22,11 @@ Describe 'Wait-BitbucketPipeline' {
             }
         }
 
-        $Pipeline | Wait-BitbucketPipeline -Team $Team
+        $Pipeline | Wait-BitbucketPipeline -Workspace $Workspace
 
         It 'Uses the repo and pipeline uuid from the pipeline input' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
-                $path -eq "repositories/$Team/$($Pipeline.repository.uuid)/pipelines/$($Pipeline.uuid)"
+                $path -eq "repositories/$Workspace/$($Pipeline.repository.uuid)/pipelines/$($Pipeline.uuid)"
             }
         }
     }

--- a/Tests/PullRequests.Tests/New-BitbucketPullRequest.Tests.ps1
+++ b/Tests/PullRequests.Tests/New-BitbucketPullRequest.Tests.ps1
@@ -8,13 +8,13 @@ Describe 'New-BitbucketPullRequest' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $Title = 'Title'
     $Source = 'SBranch'
     
     Context 'Create Basic PR' {
-        New-BitbucketPullRequest -Team $Team -RepoSlug $Repo -Title $Title -SourceBranch $Source
+        New-BitbucketPullRequest -Workspace $Workspace -RepoSlug $Repo -Title $Title -SourceBranch $Source
 
         It 'Uses Post Method' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
@@ -24,23 +24,23 @@ Describe 'New-BitbucketPullRequest' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/pullrequests"
+                $Path -eq "repositories/$Workspace/$Repo/pullrequests"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
                 ([ordered]@{
-                    title =  $Title
-                    description = ''
-                    close_source_branch = $true
-                    source = [ordered]@{
-                        branch = [ordered]@{
-                            name = $Source
+                        title               = $Title
+                        description         = ''
+                        close_source_branch = $true
+                        source              = [ordered]@{
+                            branch = [ordered]@{
+                                name = $Source
+                            }
                         }
-                    }
-                    reviewers = @()
-                } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
+                        reviewers           = @()
+                    } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
             }
         }
     }
@@ -50,10 +50,10 @@ Describe 'New-BitbucketPullRequest' {
         $Close = $false
         $Destination = 'DBranch'
         $Reviewers = @([PSCustomObject]@{
-            uuid = 'testid'
-        })
+                uuid = 'testid'
+            })
 
-        New-BitbucketPullRequest -Team $Team -RepoSlug $Repo -Title $Title -SourceBranch $Source -Description $Description -CloseBranch $Close -DestinationBranch $Destination -Reviewers $Reviewers
+        New-BitbucketPullRequest -Workspace $Workspace -RepoSlug $Repo -Title $Title -SourceBranch $Source -Description $Description -CloseBranch $Close -DestinationBranch $Destination -Reviewers $Reviewers
 
         It 'Uses Post Method' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
@@ -63,28 +63,28 @@ Describe 'New-BitbucketPullRequest' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/pullrequests"
+                $Path -eq "repositories/$Workspace/$Repo/pullrequests"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest -ParameterFilter {
                 ([ordered]@{
-                    title =  $Title
-                    description = $Description
-                    close_source_branch = $Close
-                    source = [ordered]@{
-                        branch = [ordered]@{
-                            name = $Source
+                        title               = $Title
+                        description         = $Description
+                        close_source_branch = $Close
+                        source              = [ordered]@{
+                            branch = [ordered]@{
+                                name = $Source
+                            }
                         }
-                    }
-                    reviewers = $Reviewers
-                    destination = @{
-                        branch = @{
-                            name = $Destination
+                        reviewers           = $Reviewers
+                        destination         = @{
+                            branch = @{
+                                name = $Destination
+                            }
                         }
-                    }
-                } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
+                    } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
             }
         }
     }

--- a/Tests/PullRequests.Tests/New-BitbucketPullRequestComment.Tests.ps1
+++ b/Tests/PullRequests.Tests/New-BitbucketPullRequestComment.Tests.ps1
@@ -8,13 +8,13 @@ Describe 'New-BitbucketPullRequestComment' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $ID = 1
     $Comment = 'Comment'
     
     Context 'Create plain comment' {
-        New-BitbucketPullRequestComment -Team $Team -RepoSlug $Repo -PullRequestID $ID -Comment $Comment
+        New-BitbucketPullRequestComment -Workspace $Workspace -RepoSlug $Repo -PullRequestID $ID -Comment $Comment
 
         It 'Uses Post Method' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest.Comment -ParameterFilter {
@@ -24,17 +24,17 @@ Describe 'New-BitbucketPullRequestComment' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest.Comment -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/pullrequests/$ID/comments"
+                $Path -eq "repositories/$Workspace/$Repo/pullrequests/$ID/comments"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -Exactly 1 -ModuleName Atlassian.Bitbucket.PullRequest.Comment -ParameterFilter {
                 ([ordered]@{
-                    content = [ordered]@{
-                        raw =  $Comment
-                    }
-                } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
+                        content = [ordered]@{
+                            raw = $Comment
+                        }
+                    } | ConvertTo-Json -Depth 3 -Compress) -eq $Body
             }
         }
     }

--- a/Tests/Repository.Tests/Add-BitbucketRepositoryBranch.Tests.ps1
+++ b/Tests/Repository.Tests/Add-BitbucketRepositoryBranch.Tests.ps1
@@ -3,13 +3,13 @@ Import-Module '.\Atlassian.Bitbucket.Repository.psm1' -Force
 Describe 'Add-BitbucketRepositoryBranch' {
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository {}
 
-    $Team = 'T'
+    $Workspace = 'T'
     $RepoSlug = 'R'
     $Branch = 'B'
     $Parent = 'P'
     $Message = 'M'
     
-    Add-BitbucketRepositoryBranch -Team $Team -RepoSlug $RepoSlug -Branch $Branch -Parent $Parent -Message $Message
+    Add-BitbucketRepositoryBranch -Workspace $Workspace -RepoSlug $RepoSlug -Branch $Branch -Parent $Parent -Message $Message
 
     It 'Uses POST Method' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -19,7 +19,7 @@ Describe 'Add-BitbucketRepositoryBranch' {
 
     It 'Has a valid path' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-            $Path -eq "repositories/$Team/$RepoSlug/src/"
+            $Path -eq "repositories/$Workspace/$RepoSlug/src/"
         }
     }
 
@@ -29,10 +29,10 @@ Describe 'Add-BitbucketRepositoryBranch' {
         }
     }
 
-    It 'Has a valid body'{
+    It 'Has a valid body' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-            $testBody = [ordered]@{branch=$Branch; parents=$Parent; message=$Message}
-            ($testBody.Keys.Count -eq $Body.Keys.Count) -and ($testBody.Keys | ForEach-Object {$testBody[$_] -eq $Body[$_]})
+            $testBody = [ordered]@{branch = $Branch; parents = $Parent; message = $Message }
+            ($testBody.Keys.Count -eq $Body.Keys.Count) -and ($testBody.Keys | ForEach-Object { $testBody[$_] -eq $Body[$_] })
         }
     }
 

--- a/Tests/Repository.Tests/Get-BitbucketRepository.Tests.ps1
+++ b/Tests/Repository.Tests/Get-BitbucketRepository.Tests.ps1
@@ -8,11 +8,11 @@ Describe 'Get-BitbucketRepository' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     
     Context 'Get single repo' {
         $Repo = 'R'
-        Get-BitbucketRepository -Team $Team -RepoSlug $Repo
+        Get-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo
 
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -22,11 +22,11 @@ Describe 'Get-BitbucketRepository' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo"
+                $Path -eq "repositories/$Workspace/$Repo"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 $Body -eq $null
             }
@@ -40,11 +40,11 @@ Describe 'Get-BitbucketRepository' {
     }
 
     Context 'Get all repos' {
-        Get-BitbucketRepository -Team $Team
+        Get-BitbucketRepository -Workspace $Workspace
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team"
+                $Path -eq "repositories/$Workspace"
             }
         }
 
@@ -57,11 +57,11 @@ Describe 'Get-BitbucketRepository' {
 
     Context 'Get all project repos' {
         $Key = 'K'
-        Get-BitbucketRepository -Team $Team -ProjectKey $Key
+        Get-BitbucketRepository -Workspace $Workspace -ProjectKey $Key
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$($Team)?q=project.key=%22$Key%22"
+                $Path -eq "repositories/$($Workspace)?q=project.key=%22$Key%22"
             }
         }
 

--- a/Tests/Repository.Tests/Get-BitbucketRepositoryBranch.Tests.ps1
+++ b/Tests/Repository.Tests/Get-BitbucketRepositoryBranch.Tests.ps1
@@ -8,12 +8,12 @@ Describe 'Get-BitbucketRepositoryBranch' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     $Name = 'feature'
 
     Context 'Get all branches' {
-        Get-BitbucketRepositoryBranch -Team $Team -RepoSlug $Repo
+        Get-BitbucketRepositoryBranch -Workspace $Workspace -RepoSlug $Repo
 
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -23,11 +23,11 @@ Describe 'Get-BitbucketRepositoryBranch' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/refs/branches?q=name~`"`""
+                $Path -eq "repositories/$Workspace/$Repo/refs/branches?q=name~`"`""
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 $Body -eq $null
             }
@@ -41,7 +41,7 @@ Describe 'Get-BitbucketRepositoryBranch' {
     }
 
     Context 'Get specified branches' {
-        Get-BitbucketRepositoryBranch -Team $Team -RepoSlug $Repo -Name $Name
+        Get-BitbucketRepositoryBranch -Workspace $Workspace -RepoSlug $Repo -Name $Name
 
         It 'Uses default GET Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -51,11 +51,11 @@ Describe 'Get-BitbucketRepositoryBranch' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo/refs/branches?q=name~`"$Name`""
+                $Path -eq "repositories/$Workspace/$Repo/refs/branches?q=name~`"$Name`""
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 $Body -eq $null
             }

--- a/Tests/Repository.Tests/New-BitbucketRepository.Tests.ps1
+++ b/Tests/Repository.Tests/New-BitbucketRepository.Tests.ps1
@@ -8,11 +8,11 @@ Describe 'New-BitbucketRepository' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Create new repo with only required params' {
-        New-BitbucketRepository -Team $Team -RepoSlug $Repo
+        New-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo
 
         It 'Uses POST Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -22,41 +22,41 @@ Describe 'New-BitbucketRepository' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo"
+                $Path -eq "repositories/$Workspace/$Repo"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    scm = 'git'
-                    is_private = $true
-                    name = $Repo
-                    description = ''
-                    language = ''
-                    fork_policy = 'no_forks'
-                } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
+                        scm         = 'git'
+                        is_private  = $true
+                        name        = $Repo
+                        description = ''
+                        language    = ''
+                        fork_policy = 'no_forks'
+                    } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
             }
         }
     }
 
     Context 'Create new repo with a project specified' {
         $Key = 'K'
-        New-BitbucketRepository -Team $Team -RepoSlug $Repo -ProjectKey $Key
+        New-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -ProjectKey $Key
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    scm = 'git'
-                    project = [ordered]@{
-                        key = $Key
-                    }
-                    is_private = $true
-                    name = $Repo
-                    description = ''
-                    language = ''
-                    fork_policy = 'no_forks'
-                } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
+                        scm         = 'git'
+                        project     = [ordered]@{
+                            key = $Key
+                        }
+                        is_private  = $true
+                        name        = $Repo
+                        description = ''
+                        language    = ''
+                        fork_policy = 'no_forks'
+                    } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
             }
         }
     }
@@ -68,21 +68,21 @@ Describe 'New-BitbucketRepository' {
         $Description = 'desc'
         $Language = 'powershell'
         $Fork = 'allow_forks'
-        New-BitbucketRepository -Team $Team -RepoSlug $Repo -Name $Name -ProjectKey $Key -Private $Private -Description $Description -Language $Language -ForkPolicy $Fork
+        New-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -Name $Name -ProjectKey $Key -Private $Private -Description $Description -Language $Language -ForkPolicy $Fork
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    scm = 'git'
-                    project = [ordered]@{
-                        key = $Key
-                    }
-                    is_private = $Private
-                    name = $Name
-                    description = $Description
-                    language = $Language
-                    fork_policy = $Fork
-                } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
+                        scm         = 'git'
+                        project     = [ordered]@{
+                            key = $Key
+                        }
+                        is_private  = $Private
+                        name        = $Name
+                        description = $Description
+                        language    = $Language
+                        fork_policy = $Fork
+                    } | ConvertTo-Json -Depth 2 -Compress) -eq $Body
             }
         }
     }

--- a/Tests/Repository.Tests/Remove-BitbucketRepository.Tests.ps1
+++ b/Tests/Repository.Tests/Remove-BitbucketRepository.Tests.ps1
@@ -5,11 +5,11 @@ Describe 'Remove-BitbucketRepository' {
         return $null
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Remove Repo' {
-        Remove-BitbucketRepository -Team $Team -RepoSlug $Repo -Confirm:$false
+        Remove-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -Confirm:$false
 
         It 'Uses DELETE Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -19,11 +19,11 @@ Describe 'Remove-BitbucketRepository' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo"
+                $Path -eq "repositories/$Workspace/$Repo"
             }
         }
 
-        It 'Has no body'{
+        It 'Has no body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 $Body -eq $null
             }
@@ -32,24 +32,24 @@ Describe 'Remove-BitbucketRepository' {
 
     Context 'Accepts pipeline input' {
         $Repo = New-Object PSObject -Property @{
-            scm = 'git'
-            uuid = (New-Guid)
-            slug = 'reponame'
+            scm         = 'git'
+            uuid        = (New-Guid)
+            slug        = 'reponame'
             description = 'desc'
-            language = 'powershell'
+            language    = 'powershell'
         }
 
-        $Repo | Remove-BitbucketRepository -Team $Team -Confirm:$false
+        $Repo | Remove-BitbucketRepository -Workspace $Workspace -Confirm:$false
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$($Repo.slug)"
+                $Path -eq "repositories/$Workspace/$($Repo.slug)"
             }
         }
     }
 
     Context 'Supports WhatIf' {
-        Remove-BitbucketRepository -Team $Team -RepoSlug $Repo -WhatIf
+        Remove-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -WhatIf
 
         It 'Does not call the mock' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -Exactly 0

--- a/Tests/Repository.Tests/Set-BitbucketRepository.Tests.ps1
+++ b/Tests/Repository.Tests/Set-BitbucketRepository.Tests.ps1
@@ -8,12 +8,12 @@ Describe 'Set-BitbucketRepository' {
         return $Response
     }
 
-    $Team = 'T'
+    $Workspace = 'T'
     $Repo = 'R'
     
     Context 'Updating Project' {
         $Key = 'K'
-        Set-BitbucketRepository -Team $Team -RepoSlug $Repo -ProjectKey $Key
+        Set-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -ProjectKey $Key
 
         It 'Uses PUT Method' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
@@ -23,17 +23,17 @@ Describe 'Set-BitbucketRepository' {
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$Repo"
+                $Path -eq "repositories/$Workspace/$Repo"
             }
         }
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    project = [ordered]@{
-                        key = $Key
-                    }
-                } | ConvertTo-Json -Compress) -eq $Body
+                        project = [ordered]@{
+                            key = $Key
+                        }
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
@@ -41,51 +41,51 @@ Describe 'Set-BitbucketRepository' {
     Context 'Updating Project and Language' {
         $Key = 'K'
         $Language = 'powershell'
-        Set-BitbucketRepository -Team $Team -RepoSlug $Repo -ProjectKey $Key -Language $Language
+        Set-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo -ProjectKey $Key -Language $Language
 
-        It 'Has a valid body'{
+        It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    project  = [ordered]@{
-                        key  = $Key
-                    }
-                    language = $Language
-                } | ConvertTo-Json -Compress) -eq $Body
+                        project  = [ordered]@{
+                            key = $Key
+                        }
+                        language = $Language
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }
 
     Context 'Provides no properties to set' {
         It 'Should throw an error' {
-            {Set-BitbucketRepository -Team $Team -RepoSlug $Repo} | Should -Throw
+            { Set-BitbucketRepository -Workspace $Workspace -RepoSlug $Repo } | Should -Throw
         }
     }
 
     Context 'Accepts pipeline input only for slug' {
         $Key = 'K'
         $Repo = New-Object PSObject -Property @{
-            scm = 'git'
-            uuid = (New-Guid)
-            slug = 'reponame'
+            scm         = 'git'
+            uuid        = (New-Guid)
+            slug        = 'reponame'
             description = 'desc'
-            language = 'powershell'
+            language    = 'powershell'
         }
 
-        $Repo | Set-BitbucketRepository -Team $Team -ProjectKey $Key
+        $Repo | Set-BitbucketRepository -Workspace $Workspace -ProjectKey $Key
 
         It 'Has a valid path' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
-                $Path -eq "repositories/$Team/$($Repo.slug)"
+                $Path -eq "repositories/$Workspace/$($Repo.slug)"
             }
         }
 
-        It 'Has a valid body with no other properties'{
+        It 'Has a valid body with no other properties' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository -ParameterFilter {
                 ([ordered]@{
-                    project  = [ordered]@{
-                        key  = $Key
-                    }
-                } | ConvertTo-Json -Compress) -eq $Body
+                        project = [ordered]@{
+                            key = $Key
+                        }
+                    } | ConvertTo-Json -Compress) -eq $Body
             }
         }
     }

--- a/Tests/Reviewer.Tests/Set-BitbucketRepositoryReviewer.Tests.ps1
+++ b/Tests/Reviewer.Tests/Set-BitbucketRepositoryReviewer.Tests.ps1
@@ -1,7 +1,7 @@
 Import-Module '.\Atlassian.Bitbucket.Repository.Reviewer.psm1' -Force
 
 Describe 'Set-BitbucketRepositoryReviewer' {
-    $SpecifiedTeam = 'T'
+    $SpecifiedWorkspace = 'T'
     $SpecifiedRepoSlug = 'R'
     $SpecifiedUUID = 'fake1'
 
@@ -10,11 +10,11 @@ Describe 'Set-BitbucketRepositoryReviewer' {
     Mock Remove-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer { }
 
     Context 'No default reviewers exist' {
-        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Team $SpecifiedTeam -UUIDs $SpecifiedUUID
+        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Workspace $SpecifiedWorkspace -UUIDs $SpecifiedUUID
 
         It 'Adds the specified user to the specified repo' {
             Assert-MockCalled Add-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer -ParameterFilter {
-                $UUID -eq $SpecifiedUUID -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedTeam -eq $Team
+                $UUID -eq $SpecifiedUUID -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedWorkspace -eq $Workspace
             }
         }
     }
@@ -29,11 +29,11 @@ Describe 'Set-BitbucketRepositoryReviewer' {
             return $ExistingUsers
         }
 
-        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Team $SpecifiedTeam -UUIDs $SpecifiedUUID
+        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Workspace $SpecifiedWorkspace -UUIDs $SpecifiedUUID
 
         It 'Only adds the expected user to the specified repo' {
             Assert-MockCalled Add-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer -ParameterFilter {
-                $UUID -eq 'fake2' -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedTeam -eq $Team
+                $UUID -eq 'fake2' -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedWorkspace -eq $Workspace
             }
             Assert-MockCalled Add-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer -Exactly 1
         }
@@ -48,11 +48,11 @@ Describe 'Set-BitbucketRepositoryReviewer' {
             }
             return $ExistingUsers
         }
-        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Team $SpecifiedTeam -UUIDs $SpecifiedUUID
+        Set-BitbucketRepositoryReviewer -RepoSlug $SpecifiedRepoSlug -Workspace $SpecifiedWorkspace -UUIDs $SpecifiedUUID
 
         It 'Only removes the extra user from the specified repo' {
             Assert-MockCalled Remove-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer -ParameterFilter {
-                $UUID -eq 'fake2' -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedTeam -eq $Team
+                $UUID -eq 'fake2' -and $SpecifiedRepoSlug -eq $RepoSlug -and $SpecifiedWorkspace -eq $Workspace
             }
             Assert-MockCalled Remove-BitbucketRepositoryReviewer -ModuleName Atlassian.Bitbucket.Repository.Reviewer -Exactly 1
         }

--- a/Tests/User.Tests/Add-BitbucketUserToGroup.Tests.ps1
+++ b/Tests/User.Tests/Add-BitbucketUserToGroup.Tests.ps1
@@ -1,13 +1,13 @@
 Import-Module '.\Atlassian.Bitbucket.User.psm1' -Force
 
 Describe 'Add-BitbucketUserToGroup' {
-    $Team = 'T'
+    $Workspace = 'T'
     $GroupSlug = 'G'
     $UserUuid = 'U'
 
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User {}
 
-    Add-BitbucketUserToGroup -Team $Team -GroupSlug $GroupSlug -UserUuid $UserUuid
+    Add-BitbucketUserToGroup -Workspace $Workspace -GroupSlug $GroupSlug -UserUuid $UserUuid
 
     It 'Uses PUT Method' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
@@ -17,7 +17,7 @@ Describe 'Add-BitbucketUserToGroup' {
     
     It 'Has a valid path' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
-            $Path -eq "groups/$Team/$GroupSlug/members/$UserUuid"
+            $Path -eq "groups/$Workspace/$GroupSlug/members/$UserUuid"
         }
     }
 
@@ -27,7 +27,7 @@ Describe 'Add-BitbucketUserToGroup' {
         }
     }
 
-    It 'Uses v1 API'{
+    It 'Uses v1 API' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
             '1.0' -eq $API_Version
         }

--- a/Tests/User.Tests/Get-BitbucketGroup.Tests.ps1
+++ b/Tests/User.Tests/Get-BitbucketGroup.Tests.ps1
@@ -1,15 +1,15 @@
 Import-Module '.\Atlassian.Bitbucket.User.psm1' -Force
 
 Describe 'Get-BitbucketGroup' {
-    $Team = 'T'
+    $Workspace = 'T'
 
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User {}
 
-    Get-BitbucketGroup -Team $Team
+    Get-BitbucketGroup -Workspace $Workspace
 
     It 'Has a valid path' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
-            $Path -eq "groups/$Team"
+            $Path -eq "groups/$Workspace"
         }
     }
 
@@ -19,7 +19,7 @@ Describe 'Get-BitbucketGroup' {
         }
     }
 
-    It 'Uses v1 API'{
+    It 'Uses v1 API' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
             '1.0' -eq $API_Version
         }

--- a/Tests/User.Tests/Get-BitbucketUser.Tests.ps1
+++ b/Tests/User.Tests/Get-BitbucketUser.Tests.ps1
@@ -1,15 +1,15 @@
 Import-Module '.\Atlassian.Bitbucket.User.psm1' -Force
 
 Describe 'Get-BitbucketUser' {
-    $Team = 'T'
+    $Workspace = 'T'
 
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User {}
 
-    Get-BitbucketUser -Team $Team
+    Get-BitbucketUser -Workspace $Workspace
 
     It 'Has a valid path' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
-            $Path -eq "users/$Team/members"
+            $Path -eq "workspaces/$Workspace/members"
         }
     }
 

--- a/Tests/User.Tests/Get-BitbucketUserByGroup.Tests.ps1
+++ b/Tests/User.Tests/Get-BitbucketUserByGroup.Tests.ps1
@@ -1,16 +1,16 @@
 Import-Module '.\Atlassian.Bitbucket.User.psm1' -Force
 
 Describe 'Get-BitbucketUserByGroup' {
-    $Team = 'T'
+    $Workspace = 'T'
     $GroupSlug = 'G'
 
     Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User {}
 
-    Get-BitbucketUsersByGroup -Team $Team -GroupSlug $GroupSlug
+    Get-BitbucketUsersByGroup -Workspace $Workspace -GroupSlug $GroupSlug
 
     It 'Has a valid path' {
         Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.User -ParameterFilter {
-            $Path -eq "groups/$Team/$GroupSlug/members"
+            $Path -eq "groups/$Workspace/$GroupSlug/members"
         }
     }
 


### PR DESCRIPTION
Select-Object returns all properties in PowerShell version 5.1 when the caller specifies the -ExcludeProperty parameter, but does not specify the -Properties parameter.