### PR TITLE
branch_type is only valid when branch_match_kind is branching_model

### DIFF
--- a/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
+++ b/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
@@ -51,7 +51,7 @@ function Add-BitbucketRepositoryBranchRestriction {
 
         # If the branch_match_kind is Glob, remove branch_type property, otherwise the Bitbucket API will throw an exception
         if ($Restriction.branch_match_kind -eq 'Glob') {
-            $globRestriction = $Restriction | Select-Object -ExcludeProperty branch_type
+            $globRestriction = $Restriction | Select-Object -ExcludeProperty branch_type -Property *
             $body = $globRestriction | ConvertTo-Json -Depth 3 -Compress
         }
         else {

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.29.0'
+    ModuleVersion     = '0.29.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _These will be removed in the next major release_
 
 ## 0.29.0
 - Updated team cmdlets to workspace while retaining old names with alias https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/
+- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model
 
 ## 0.28.0
 - Added `Add-BitbucketRepositoryBranch` to create a new branch in a repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ _These will be removed in the next major release_
 
 - N/A
 
+## 0.29.1
+- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model
+
 ## 0.29.0
 - Updated team cmdlets to workspace while retaining old names with alias https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/
-- Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model
 
 ## 0.28.0
 - Added `Add-BitbucketRepositoryBranch` to create a new branch in a repo

--- a/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
         It "Removes the branch_type property when branch_match_kind equals 'glob'" {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
-                $null -eq ($Body | ConvertFrom-Json -Depth 3).branch_match_kind
+                $null -eq ($Body | ConvertFrom-Json -Depth 3 | Select-Object -ExpandProperty branch_type -ErrorAction Ignore)
             }
         }
     }

--- a/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
+++ b/Tests/BranchRestriction.Tests/Add-BitbucketRepositoryBranchRestriction.Tests.ps1
@@ -1,7 +1,7 @@
 Import-Module '.\Atlassian.Bitbucket.Repository.BranchRestriction.psm1' -Force
 
 Describe 'Add-BitbucketRepositoryBranchRestriction' {
-    Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction { 
+    Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction {
         $Response = New-Object PSObject -Property @{
             id = (New-Guid).Guid
         }
@@ -10,7 +10,7 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
 
     $Workspace = 'T'
     $Repo = 'R'
-    
+
     Context 'Create new Glob based branch restriction' {
         $MergeCheck = New-BitbucketRepositoryBranchRestrictionMergeCheck -Kind 'require_approvals_to_merge' -Pattern 'master' -Value 2
         Add-BitbucketRepositoryBranchRestriction -Workspace $Workspace -RepoSlug $Repo -Restriction $MergeCheck
@@ -30,6 +30,12 @@ Describe 'Add-BitbucketRepositoryBranchRestriction' {
         It 'Has a valid body' {
             Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
                 ($MergeCheck | Select-Object -ExcludeProperty branch_type | ConvertTo-Json -Depth 2 -Compress) -eq $Body
+            }
+        }
+
+        It "Removes the branch_type property when branch_match_kind equals 'glob'" {
+            Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Repository.BranchRestriction -ParameterFilter {
+                $null -eq ($Body | ConvertFrom-Json -Depth 3).branch_match_kind
             }
         }
     }


### PR DESCRIPTION
Fixed issue running Add-BitbucketRepositoryBranchRestriction that caused error branch_type is only valid when branch_match_kind is branching_model