### PR TITLE
Add New CMDlets

### DIFF
--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -145,6 +145,7 @@ function Invoke-BitbucketAPI {
 
         return $response
     }else{
+        Write-Debug "URI: $URI"
         if($Body){
             Write-Debug 'Sending request with a body and content type'
             Write-Debug "Body: $Body"

--- a/Atlassian.Bitbucket.Pipeline.psm1
+++ b/Atlassian.Bitbucket.Pipeline.psm1
@@ -309,6 +309,6 @@ function Get-BitbucketPipelineStep {
 
   Process {
       $endpoint = "repositories/$Workspace/$RepoSlug/pipelines/$PipelineUUID/steps/$UUID`?pagelen=100"
-      return (Invoke-BitbucketAPI -Path $endpoint -Method Get -Debug).values
+      return (Invoke-BitbucketAPI -Path $endpoint -Method Get).values
   }
 }

--- a/Atlassian.Bitbucket.Pipeline.psm1
+++ b/Atlassian.Bitbucket.Pipeline.psm1
@@ -241,7 +241,6 @@ function Get-BitbucketPipeline {
         $endpoint = "repositories/$Workspace/$RepoSlug/pipelines/"
         if ($UUID) {
             $endpoint += "$UUID"
-            Write-Host $endpoint
             return @(Invoke-BitbucketAPI -Path $endpoint -Method Get)
         }
         else {
@@ -249,7 +248,6 @@ function Get-BitbucketPipeline {
             if ($State) {
                 $endpoint += "&status=$($State.ToUpper())"
             }
-            Write-Host $endpoint
             return (Invoke-BitbucketAPI -Path $endpoint -Method Get).values
         }
 

--- a/Atlassian.Bitbucket.Pipeline.psm1
+++ b/Atlassian.Bitbucket.Pipeline.psm1
@@ -161,6 +161,9 @@ function Wait-BitbucketPipeline {
             if ($response.state.name -eq 'COMPLETED') {
                 $poll = $false
             }
+            elseif($response.state.name -in ('PENDING', 'IN_PROGRESS') -and $response.state.stage.name -in ('PAUSED', 'HALTED')){
+                Throw "The triggered pipeline was $($response.state.stage.name).  Failing Build!!"
+            }
             else {
                 if ($TimeoutSeconds -lt $SleepSeconds) {
                     Throw "The $TimeoutSeconds second timeout expired before the pipeline completed."

--- a/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
+++ b/Atlassian.Bitbucket.Repository.BranchRestriction.psm1
@@ -237,6 +237,7 @@ function New-BitbucketRepositoryBranchRestrictionPermissionCheck {
 }
 
 function ConvertTo-BranchRestriction {
+    [OutputType([MergeCheck])]
     [CmdletBinding()]
     param(
         [Parameter( Mandatory = $true,

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.29.1'
+    ModuleVersion     = '0.30.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')
@@ -94,7 +94,9 @@
         'Add-BitbucketUserToGroup',
         'Enable-BitbucketPipelineConfig',
         'Get-BitbucketLogin',
+        'Get-BitbucketPipeline',
         'Get-BitbucketPipelineConfig',
+        'Get-BitbucketPipelineStep',
         'Get-BitbucketProject',
         'Get-BitbucketProjectDeploymentReport',
         'Get-BitbucketPullRequest',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _These will be removed in the next major release_
 
 - N/A
 
+## 0.30.0
+- Added `Get-BitbucketPipeline` to return details on a specific pipeline or get an array of pipelines
+- Added `Get-BitbucketPipelineStep` to return details on a specific pipeline step or get an array of pipeline steps
+
 ## 0.29.1
 - Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _These will be removed in the next major release_
 ## 0.30.0
 - Added `Get-BitbucketPipeline` to return details on a specific pipeline or get an array of pipelines
 - Added `Get-BitbucketPipelineStep` to return details on a specific pipeline step or get an array of pipeline steps
+- Updated `Wait-BitbucketPipeline` to throw an error if the pipeline gets paused or halted
 
 ## 0.29.1
 - Fixed issue running `Add-BitbucketRepositoryBranchRestriction` that caused error `branch_type is only valid when branch_match_kind is branching_model

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ To get more information on each cmdlet run `Get-Help <CMDLET Name>`
 #### Pipeline CMDLETs
 
 - `Enable-BitbucketPipelineConfig`
+- `Get-BitbucketPipeline`
 - `Get-BitbucketPipelineConfig`
+- `Get-BitbucketPipelineStep`
 - `Start-BitbucketPipeline`
 - `Wait-BitbucketPipeline`
 

--- a/Tests/Pipeline.Tests/Get-BitbucketPipeline.Tests.ps1
+++ b/Tests/Pipeline.Tests/Get-BitbucketPipeline.Tests.ps1
@@ -1,0 +1,28 @@
+Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
+
+Describe "Get-BitbucketPipeline" {
+  $Workspace = 'T'
+  $Repo = 'R'
+
+  Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline {}
+
+  Get-BitbucketPipeline -RepoSlug $Repo -Workspace $Workspace
+
+  It 'Has a valid path' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $Path -like "repositories/$Workspace/$Repo/pipelines/*"
+    }
+  }
+
+  It 'Uses the Get method' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $Method -eq 'Get'
+    }
+  }
+
+  It 'Has no body' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $null -eq $Body
+    }
+  }
+}

--- a/Tests/Pipeline.Tests/Get-BitbucketPipelineStep.Tests.ps1
+++ b/Tests/Pipeline.Tests/Get-BitbucketPipelineStep.Tests.ps1
@@ -1,0 +1,29 @@
+Import-Module '.\Atlassian.Bitbucket.Pipeline.psm1' -Force
+
+Describe "Get-BitbucketPipelineStep" {
+  $Workspace = 'T'
+  $Repo = 'R'
+  $PipelineUUID = '1'
+
+  Mock Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline {}
+
+  Get-BitbucketPipelineStep -RepoSlug $Repo -Workspace $Workspace -PipelineUUID $PipelineUUID
+
+  It 'Has a valid path' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $Path -like "repositories/$Workspace/$Repo/pipelines/$PipelineUUID/steps/*"
+    }
+  }
+
+  It 'Uses the Get method' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $Method -eq 'Get'
+    }
+  }
+
+  It 'Has no body' {
+    Assert-MockCalled Invoke-BitbucketAPI -ModuleName Atlassian.Bitbucket.Pipeline -ParameterFilter {
+      $null -eq $Body
+    }
+  }
+}


### PR DESCRIPTION
# Why
The module currently has no way to retrieve details for a pipeline or pipeline step.

# What
- Added cmdlets for retrieving details on pipelines and pipeline steps
- Added some debug output
- Updated Wait-BitbucketPipeline to throw an error if the pipeline is paused or halted

# Testing
Tested locally against the API