### PR TITLE
Add Workspace Param to Login-Bitbucket

### DIFF
--- a/Atlassian.Bitbucket.Authentication.psm1
+++ b/Atlassian.Bitbucket.Authentication.psm1
@@ -24,6 +24,9 @@ using module .\Classes\Atlassian.Bitbucket.Settings.psm1
 
     .PARAMETER OAuthConsumer
         Key and Secret for OAuth Consumer.  https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Createaconsumer
+
+    .PARAMETER Workspace
+        Name of the workspace to authenticate to.  If not provided and multiple options exist the user will be prompted to select one.
 #>
 function New-BitbucketLogin {
     [CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Low', DefaultParameterSetName='Basic')]
@@ -35,7 +38,8 @@ function New-BitbucketLogin {
         [PSCredential]$AtlassianCredential,
         [Parameter(Mandatory = $true, ParameterSetName = 'OAuth2')]
         [PSCredential]$OAuthConsumer,
-        [Switch]$Save
+        [Switch]$Save,
+        [String]$Workspace
     )
     if ($pscmdlet.ShouldProcess('Bitbucket Login', 'create'))
     {
@@ -53,7 +57,7 @@ function New-BitbucketLogin {
 
         Write-Output "Welcome $($Auth.User.display_name)"
 
-        Select-BitbucketWorkspace
+        Select-BitbucketWorkspace -Workspace $Workspace
 
         if($Save){
             Save-BitbucketLogin

--- a/Atlassian.Bitbucket.psd1
+++ b/Atlassian.Bitbucket.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Atlassian.Bitbucket.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.30.0'
+    ModuleVersion     = '0.31.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @('Desktop', 'Core')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _These will be removed in the next major release_
 
 - N/A
 
+## 0.31.0
+- Updated `New-BitbucketLogin` to support passing in a Workspace name
 ## 0.30.0
 - Added `Get-BitbucketPipeline` to return details on a specific pipeline or get an array of pipelines
 - Added `Get-BitbucketPipelineStep` to return details on a specific pipeline step or get an array of pipeline steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _These will be removed in the next major release_
 
 ## 0.31.0
 - Updated `New-BitbucketLogin` to support passing in a Workspace name
+
 ## 0.30.0
 - Added `Get-BitbucketPipeline` to return details on a specific pipeline or get an array of pipelines
 - Added `Get-BitbucketPipelineStep` to return details on a specific pipeline step or get an array of pipeline steps


### PR DESCRIPTION
# Why
Bitbucket now includes your personal space as an option when logging into the API.  That means that even service accounts will be prompted to select a workspace.  

# What
- Added a `Workspace` parameter to Login-Bitbucket so that automation accounts can provide this instead of getting prompted to select a workspace.
